### PR TITLE
fix module declaration

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ 'main' ]
 
 env:
-  GO_VERSION: "1.24.0"
+  GO_VERSION: "1.24.1"
   GO_LANG_CI_LINT_VERSION: "v1.64.6"
 
 jobs:

--- a/checks/alloy/alloyChecker.go
+++ b/checks/alloy/alloyChecker.go
@@ -1,5 +1,5 @@
 package alloy
 
-import "otel-checker/checks/utils"
+import "github.com/grafana/otel-checker/checks/utils"
 
 func CheckAlloySetup(reporter *utils.ComponentReporter, language string) {}

--- a/checks/beyla/beylaChecker.go
+++ b/checks/beyla/beylaChecker.go
@@ -1,8 +1,8 @@
 package beyla
 
 import (
-	"otel-checker/checks/env"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/env"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 var (

--- a/checks/beyla/beylaChecker_test.go
+++ b/checks/beyla/beylaChecker_test.go
@@ -3,7 +3,7 @@ package beyla
 import (
 	"testing"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func TestCheckEnvVarsBeyla(t *testing.T) {

--- a/checks/checks.go
+++ b/checks/checks.go
@@ -1,18 +1,18 @@
 package checks
 
 import (
-	"otel-checker/checks/alloy"
-	"otel-checker/checks/beyla"
-	"otel-checker/checks/collector"
-	"otel-checker/checks/env"
-	"otel-checker/checks/grafana"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/sdk/dotnet"
-	_go "otel-checker/checks/sdk/go"
-	"otel-checker/checks/sdk/java"
-	"otel-checker/checks/sdk/js"
-	"otel-checker/checks/sdk/python"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/alloy"
+	"github.com/grafana/otel-checker/checks/beyla"
+	"github.com/grafana/otel-checker/checks/collector"
+	"github.com/grafana/otel-checker/checks/env"
+	"github.com/grafana/otel-checker/checks/grafana"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/sdk/dotnet"
+	_go "github.com/grafana/otel-checker/checks/sdk/go"
+	"github.com/grafana/otel-checker/checks/sdk/java"
+	"github.com/grafana/otel-checker/checks/sdk/js"
+	"github.com/grafana/otel-checker/checks/sdk/python"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func RunAllChecks(commands utils.Commands) map[string][]string {

--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -2,8 +2,8 @@ package collector
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
-	"otel-checker/checks/utils"
 	"regexp"
 	"slices"
 	"strings"

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -1,8 +1,8 @@
 package collector
 
 import (
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
-	"otel-checker/checks/utils"
 	"path/filepath"
 	"testing"
 

--- a/checks/env/common.go
+++ b/checks/env/common.go
@@ -2,7 +2,7 @@ package env
 
 import (
 	"fmt"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 	"strings"
 )
 

--- a/checks/env/common_test.go
+++ b/checks/env/common_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func TestParseResourceAttributes(t *testing.T) {

--- a/checks/env/env.go
+++ b/checks/env/env.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 // EnvVar represents an environment variable configuration

--- a/checks/grafana/grafanaChecker.go
+++ b/checks/grafana/grafanaChecker.go
@@ -2,9 +2,9 @@ package grafana
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/env"
+	"github.com/grafana/otel-checker/checks/utils"
 	"net/http"
-	"otel-checker/checks/env"
-	"otel-checker/checks/utils"
 	"regexp"
 	"strings"
 )

--- a/checks/grafana/grafana_test.go
+++ b/checks/grafana/grafana_test.go
@@ -3,7 +3,7 @@ package grafana
 import (
 	"testing"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func TestCheckEnvVarsGrafana(t *testing.T) {

--- a/checks/sdk/dotnet/dotnetChecker.go
+++ b/checks/sdk/dotnet/dotnetChecker.go
@@ -2,8 +2,8 @@ package dotnet
 
 import (
 	"fmt"
-	"otel-checker/checks/env"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/env"
+	"github.com/grafana/otel-checker/checks/utils"
 	"strconv"
 )
 

--- a/checks/sdk/dotnet/dotnet_test.go
+++ b/checks/sdk/dotnet/dotnet_test.go
@@ -3,7 +3,7 @@ package dotnet
 import (
 	"testing"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func TestCheckDotNetAutoInstrumentation(t *testing.T) {

--- a/checks/sdk/go/goChecker.go
+++ b/checks/sdk/go/goChecker.go
@@ -1,7 +1,7 @@
 package _go
 
 import (
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func CheckGoSetup(reporter *utils.ComponentReporter, commands utils.Commands) {

--- a/checks/sdk/go/supported-libraries.go
+++ b/checks/sdk/go/supported-libraries.go
@@ -3,9 +3,9 @@ package _go
 import (
 	_ "embed"
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
-	"otel-checker/checks/sdk/supported"
-	"otel-checker/checks/utils"
 	"strings"
 )
 

--- a/checks/sdk/go/supported-libraries_test.go
+++ b/checks/sdk/go/supported-libraries_test.go
@@ -1,7 +1,7 @@
 package _go
 
 import (
-	"otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
 	"testing"
 )
 

--- a/checks/sdk/java/gradle.go
+++ b/checks/sdk/java/gradle.go
@@ -2,9 +2,9 @@ package java
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os/exec"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/utils"
 	"slices"
 	"strings"
 )

--- a/checks/sdk/java/javaChecker.go
+++ b/checks/sdk/java/javaChecker.go
@@ -3,10 +3,10 @@ package java
 import (
 	_ "embed"
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os/exec"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/sdk/supported"
-	"otel-checker/checks/utils"
 	"strconv"
 	"strings"
 )

--- a/checks/sdk/java/javaChecker_test.go
+++ b/checks/sdk/java/javaChecker_test.go
@@ -1,9 +1,9 @@
 package java
 
 import (
+	"github.com/grafana/otel-checker/checks/sdk/supported"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"otel-checker/checks/sdk/supported"
 	"testing"
 )
 

--- a/checks/sdk/java/maven.go
+++ b/checks/sdk/java/maven.go
@@ -3,9 +3,9 @@ package java
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os/exec"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/utils"
 	"strings"
 )
 

--- a/checks/sdk/java/supported.go
+++ b/checks/sdk/java/supported.go
@@ -2,10 +2,10 @@ package java
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/utils"
 	"golang.org/x/mod/semver"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/sdk/supported"
-	"otel-checker/checks/utils"
 	"path/filepath"
 	"slices"
 	"strings"

--- a/checks/sdk/js/javascriptChecker.go
+++ b/checks/sdk/js/javascriptChecker.go
@@ -2,10 +2,10 @@ package js
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/env"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
 	"os/exec"
-	"otel-checker/checks/env"
-	"otel-checker/checks/utils"
 	"strconv"
 	"strings"
 )

--- a/checks/sdk/js/javascript_test.go
+++ b/checks/sdk/js/javascript_test.go
@@ -3,7 +3,7 @@ package js
 import (
 	"testing"
 
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 func TestCheckEnvVars(t *testing.T) {

--- a/checks/sdk/js/supported-libraries.go
+++ b/checks/sdk/js/supported-libraries.go
@@ -4,9 +4,9 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
-	"otel-checker/checks/sdk/supported"
-	"otel-checker/checks/utils"
 	"strings"
 )
 

--- a/checks/sdk/js/supported-libraries_test.go
+++ b/checks/sdk/js/supported-libraries_test.go
@@ -1,7 +1,7 @@
 package js
 
 import (
-	"otel-checker/checks/sdk/supported"
+	"github.com/grafana/otel-checker/checks/sdk/supported"
 	"testing"
 )
 

--- a/checks/sdk/phpChecker.go
+++ b/checks/sdk/phpChecker.go
@@ -1,9 +1,9 @@
 package sdk
 
 import (
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
 	"os/exec"
-	"otel-checker/checks/utils"
 	"strings"
 )
 

--- a/checks/sdk/python/pythonChecker.go
+++ b/checks/sdk/python/pythonChecker.go
@@ -3,9 +3,9 @@ package python
 import (
 	_ "embed"
 	"fmt"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/utils"
 	"regexp"
 	"strconv"
 	"strings"

--- a/checks/sdk/python/pythonChecker_test.go
+++ b/checks/sdk/python/pythonChecker_test.go
@@ -1,8 +1,8 @@
 package python
 
 import (
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/utils"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/checks/sdk/rubyChecker.go
+++ b/checks/sdk/rubyChecker.go
@@ -1,9 +1,9 @@
 package sdk
 
 import (
+	"github.com/grafana/otel-checker/checks/utils"
 	"os"
 	"os/exec"
-	"otel-checker/checks/utils"
 	"strings"
 
 	"golang.org/x/mod/semver"

--- a/checks/sdk/supported/common.go
+++ b/checks/sdk/supported/common.go
@@ -2,8 +2,8 @@ package supported
 
 import (
 	"fmt"
-	"otel-checker/checks/sdk"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/sdk"
+	"github.com/grafana/otel-checker/checks/utils"
 	"strings"
 
 	"golang.org/x/mod/semver"

--- a/checks/sdk/supported/common_test.go
+++ b/checks/sdk/supported/common_test.go
@@ -1,7 +1,7 @@
 package supported
 
 import (
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks/utils"
 	"testing"
 )
 

--- a/checks/sdk/utils.go
+++ b/checks/sdk/utils.go
@@ -2,10 +2,10 @@ package sdk
 
 import (
 	"fmt"
+	"github.com/grafana/otel-checker/checks/utils"
 	"io"
 	"net/http"
 	"os/exec"
-	"otel-checker/checks/utils"
 	"strings"
 
 	"golang.org/x/mod/semver"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/otel-checker
 
-go 1.24.0
+go 1.24.1
 
 require (
 	github.com/fatih/color v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module otel-checker
+module github.com/grafana/otel-checker
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"otel-checker/checks"
-	"otel-checker/checks/utils"
+	"github.com/grafana/otel-checker/checks"
+	"github.com/grafana/otel-checker/checks/utils"
 )
 
 //go:embed static/*


### PR DESCRIPTION
fixes 

```
go install github.com/grafana/otel-checker@latest
go: downloading github.com/grafana/otel-checker v0.0.0-20250313101532-942ae87b8125
go: github.com/grafana/otel-checker@latest: version constraints conflict:
	github.com/grafana/otel-checker@v0.0.0-20250313101532-942ae87b8125: parsing go.mod:
	module declares its path as: otel-checker
	        but was required as: github.com/grafana/otel-checker
```