### PR TITLE
fix: support current upstream Java instrumentation list format

### DIFF
--- a/checks/sdk/java/javaChecker_test.go
+++ b/checks/sdk/java/javaChecker_test.go
@@ -8,6 +8,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLoadSupportedJavaLibrariesListFormat(t *testing.T) {
+	data := []byte(`
+libraries:
+  - name: executors
+    description: Executor instrumentation
+    source_path: instrumentation/executors
+    has_javaagent: true
+    javaagent_target_versions:
+      - Java 8+
+  - name: logback-appender-1.0
+    description: Logback instrumentation
+    source_path: instrumentation/logback/logback-appender-1.0
+    library_link: https://logback.qos.ch/
+    has_javaagent: true
+    javaagent_target_versions:
+      - ch.qos.logback:logback-classic:[1.0.0,)
+    has_standalone_library: true
+`)
+
+	modules, err := LoadSupportedJavaLibraries(data)
+	require.NoError(t, err)
+	require.Contains(t, modules, "logback-appender-1.0")
+	assert.Equal(t, "https://logback.qos.ch/", modules["logback-appender-1.0"][0].Link)
+	assert.Equal(t, []string{"ch.qos.logback:logback-classic:[1.0.0,)"}, modules["logback-appender-1.0"][0].Versions)
+	assert.True(t, modules["logback-appender-1.0"][0].SupportsManualInstrumentation)
+}
+
 func TestFindSupportedLibrary(t *testing.T) {
 	modules, err := supportedLibraries()
 	require.NoError(t, err)

--- a/checks/sdk/java/supported.go
+++ b/checks/sdk/java/supported.go
@@ -157,42 +157,70 @@ func supportedLibraries() (supported.SupportedModules, error) {
 // JavaInstrumentation matches the upstream Java YAML format
 type JavaInstrumentation struct {
 	Name                     string   `yaml:"name"`
+	DisplayName              string   `yaml:"display_name"`
 	Description              string   `yaml:"description"`
 	SrcPath                  string   `yaml:"source_path"`
 	Link                     string   `yaml:"link,omitempty"`
+	LibraryLink              string   `yaml:"library_link,omitempty"`
 	JavavagentTargetVersions []string `yaml:"javaagent_target_versions"`
 	HasStandaloneLibrary     bool     `yaml:"has_standalone_library"`
+	HasJavaagent             bool     `yaml:"has_javaagent"`
 }
 
-// SupportedJavaModules is a struct that holds the supported Java libraries in upstream format
-type SupportedJavaModules struct {
+type supportedJavaModulesMap struct {
 	Libraries map[string][]JavaInstrumentation `yaml:"libraries"`
+}
+
+type supportedJavaModulesList struct {
+	Libraries []JavaInstrumentation `yaml:"libraries"`
 }
 
 // LoadSupportedJavaLibraries loads supported libraries from a YAML file and maps to generic format
 func LoadSupportedJavaLibraries(data []byte) (supported.SupportedModules, error) {
-	javaModules := SupportedJavaModules{}
-	err := yaml.Unmarshal(data, &javaModules)
-	if err != nil {
+	javaModulesMap := supportedJavaModulesMap{}
+	if err := yaml.Unmarshal(data, &javaModulesMap); err == nil && len(javaModulesMap.Libraries) > 0 {
+		return mapSupportedJavaModules(javaModulesMap.Libraries), nil
+	}
+
+	javaModulesList := supportedJavaModulesList{}
+	if err := yaml.Unmarshal(data, &javaModulesList); err != nil {
 		return nil, err
 	}
 
-	// Map from Java-specific format to generic format
+	grouped := make(map[string][]JavaInstrumentation)
+	for _, library := range javaModulesList.Libraries {
+		grouped[library.Name] = append(grouped[library.Name], library)
+	}
+	return mapSupportedJavaModules(grouped), nil
+}
+
+func mapSupportedJavaModules(modules map[string][]JavaInstrumentation) supported.SupportedModules {
 	result := make(supported.SupportedModules)
-	for moduleName, javaInstrumentations := range javaModules.Libraries {
-		instrumentations := make([]supported.Instrumentation, len(javaInstrumentations))
-		for i, javaInst := range javaInstrumentations {
-			instrumentations[i] = supported.Instrumentation{
+	for moduleName, javaInstrumentations := range modules {
+		instrumentations := make([]supported.Instrumentation, 0, len(javaInstrumentations))
+		for _, javaInst := range javaInstrumentations {
+			versions := javaInst.JavavagentTargetVersions
+			if !javaInst.HasJavaagent && len(versions) == 0 {
+				continue
+			}
+
+			link := javaInst.Link
+			if link == "" {
+				link = javaInst.LibraryLink
+			}
+
+			instrumentations = append(instrumentations, supported.Instrumentation{
 				Name:                          javaInst.Name,
 				Description:                   javaInst.Description,
 				SrcPath:                       javaInst.SrcPath,
-				Link:                          javaInst.Link,
-				Versions:                      javaInst.JavavagentTargetVersions,
+				Link:                          link,
+				Versions:                      versions,
 				SupportsManualInstrumentation: javaInst.HasStandaloneLibrary,
-			}
+			})
 		}
-		result[moduleName] = instrumentations
+		if len(instrumentations) > 0 {
+			result[moduleName] = instrumentations
+		}
 	}
-
-	return result, nil
+	return result
 }


### PR DESCRIPTION
## Summary
- update the Java supported-library loader to handle the current upstream `instrumentation-list.yaml` list format
- keep compatibility with the older mapped representation used internally by otel-checker
- add test coverage for the new list-based YAML shape

## Why
The `check` job was failing on both `#267` and `#279` because upstream `open-telemetry/opentelemetry-java-instrumentation` changed `docs/instrumentation-list.yaml` from a map shape to a list shape. `otel-checker` still assumed the old format and `TestFindSupportedLibrary` started failing.

## Verification
- `go test ./checks/sdk/java`
- `mise run check`