### PR TITLE
chore: step 1 of turning checks into library

### DIFF
--- a/checks/utils/utils.go
+++ b/checks/utils/utils.go
@@ -25,10 +25,31 @@ type Commands struct {
 	Debug                 bool
 }
 
+var (
+	SupportedLanguages  = []string{"dotnet", "go", "java", "js", "python", "ruby", "php"}
+	SupportedComponents = []string{"sdk", "beyla", "alloy", "collector", "grafana-cloud"}
+)
+
+func Validate(c Commands) error {
+	if !slices.Contains(SupportedLanguages, c.Language) {
+		return fmt.Errorf("language %q not supported. Possible values: %s", c.Language, strings.Join(SupportedLanguages, ", "))
+	}
+	if len(c.Components) == 0 {
+		return fmt.Errorf("at least one component required. Possible values: %s", strings.Join(SupportedComponents, ", "))
+	}
+	for _, comp := range c.Components {
+		if !slices.Contains(SupportedComponents, strings.TrimSpace(comp)) {
+			return fmt.Errorf("component %q not supported. Possible values: %s", comp, strings.Join(SupportedComponents, ", "))
+		}
+	}
+	if c.Language == "js" && c.ManualInstrumentation && c.InstrumentationFile == "" {
+		return fmt.Errorf(`when manual-instrumentation is set, an instrumentation file is required (InstrumentationFile or -instrumentation-file=path/to/file.js)`)
+	}
+	return nil
+}
+
 func GetArguments() Commands {
-	command := Commands{}
-	args := os.Args[1:]
-	if len(args) < 1 {
+	if len(os.Args[1:]) < 1 {
 		fmt.Println(color.RedString("You must pass a language used for your instrumentation, such as -language=js"))
 		os.Exit(1)
 	}
@@ -47,48 +68,33 @@ func GetArguments() Commands {
 	collectorConfigPath := flag.String("collector-config-path", "", `Path to collector's config.yaml file. Required if using Collector and the config file is not in the same location as the otel-checker is being executed from. E.g. "-collector-config-path=src/inst/"`)
 	flag.Parse()
 
-	possibleLanguages := []string{"dotnet", "go", "java", "js", "python", "ruby", "php"}
-	if !slices.Contains(possibleLanguages, *languageValue) {
-		fmt.Println(color.RedString(fmt.Sprintf("Language %s not supported. Possible values: dotnet, go, java, js, python, ruby", *languageValue)))
+	var components []string
+	if *componentsString != "" {
+		components = strings.Split(*componentsString, ",")
+	}
+
+	command := Commands{
+		Language:              *languageValue,
+		Components:            components,
+		WebServer:             *webServer,
+		ManualInstrumentation: *manualInstrumentation,
+		InstrumentationFile:   *instrumentationFile,
+		PackageJsonPath:       *packageJsonPath,
+		CollectorConfigPath:   *collectorConfigPath,
+		Debug:                 *debug,
+	}
+
+	if err := Validate(command); err != nil {
+		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
 	}
 
-	if *componentsString == "" {
-		fmt.Println(color.RedString(`Component flag required. Possible values: sdk, beyla, alloy, collector. E.g. -components="sdk,collector"`))
-		os.Exit(1)
+	if command.PackageJsonPath != "" && !strings.HasSuffix(command.PackageJsonPath, "/") {
+		command.PackageJsonPath = command.PackageJsonPath + "/"
 	}
-
-	possibleComponents := []string{"sdk", "beyla", "alloy", "collector", "grafana-cloud"}
-	components := strings.Split(*componentsString, ",")
-	for _, c := range components {
-		if !slices.Contains(possibleComponents, strings.Trim(c, " ")) {
-			fmt.Println(color.RedString(fmt.Sprintf(`Component %s not supported. Possible values: sdk, collector, beyla, alloy. E.g. -components="sdk,collector"`, c)))
-			os.Exit(1)
-		}
+	if command.CollectorConfigPath != "" && !strings.HasSuffix(command.CollectorConfigPath, "/") {
+		command.CollectorConfigPath = command.CollectorConfigPath + "/"
 	}
-
-	// javascript
-	if *languageValue == "js" && *instrumentationFile == "" && *manualInstrumentation {
-		fmt.Println(color.RedString(`When manual-instrumentation is being used, a instrumentation file is required. Remove "-manual-instrumentation" or "-instrumentation-file=path/to/file/file.js"`))
-		os.Exit(1)
-	}
-	if *packageJsonPath != "" && !strings.HasSuffix(*packageJsonPath, "/") {
-		*packageJsonPath = *packageJsonPath + "/"
-	}
-
-	// collector
-	if *collectorConfigPath != "" && !strings.HasSuffix(*collectorConfigPath, "/") {
-		*collectorConfigPath = *collectorConfigPath + "/"
-	}
-
-	command.Language = *languageValue
-	command.Components = components
-	command.WebServer = *webServer
-	command.ManualInstrumentation = *manualInstrumentation
-	command.InstrumentationFile = *instrumentationFile
-	command.PackageJsonPath = *packageJsonPath
-	command.CollectorConfigPath = *collectorConfigPath
-	command.Debug = *debug
 	return command
 }
 

--- a/checks/utils/utils_test.go
+++ b/checks/utils/utils_test.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      Commands
+		wantErr string
+	}{
+		{
+			name: "valid go sdk",
+			in:   Commands{Language: "go", Components: []string{"sdk"}},
+		},
+		{
+			name: "valid js collector with trimmed component",
+			in:   Commands{Language: "js", Components: []string{"sdk", " collector"}},
+		},
+		{
+			name:    "unsupported language",
+			in:      Commands{Language: "rust", Components: []string{"sdk"}},
+			wantErr: `language "rust" not supported`,
+		},
+		{
+			name:    "empty language",
+			in:      Commands{Components: []string{"sdk"}},
+			wantErr: `language "" not supported`,
+		},
+		{
+			name:    "no components",
+			in:      Commands{Language: "go"},
+			wantErr: "at least one component required",
+		},
+		{
+			name:    "unsupported component",
+			in:      Commands{Language: "go", Components: []string{"sdk", "bogus"}},
+			wantErr: `component "bogus" not supported`,
+		},
+		{
+			name: "js manual without instrumentation file",
+			in: Commands{
+				Language:              "js",
+				Components:            []string{"sdk"},
+				ManualInstrumentation: true,
+			},
+			wantErr: "manual-instrumentation is set",
+		},
+		{
+			name: "js manual with instrumentation file",
+			in: Commands{
+				Language:              "js",
+				Components:            []string{"sdk"},
+				ManualInstrumentation: true,
+				InstrumentationFile:   "src/inst.js",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.in)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() returned unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() returned nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Exposed `SupportedLanguages` and `SupportedComponents` as exported vars: gcx will need them when wiring cobra flag help text.
- New `Validate(c Commands) error`: pure validation, no I/O, no exits. Returns wrapped errors. This is what gcx will call.
- Refactored `GetArguments()` to build the `Commands{} `first, then call `Validate`. If validation fails the CLI behavior is unchanged: prints red, `os.Exit(1)`. 