### PR TITLE
Reporter object

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -15,7 +15,10 @@ import (
 	"github.com/grafana/otel-checker/checks/utils"
 )
 
-func RunAllChecks(commands utils.Commands) map[string][]string {
+// Run executes all configured checks and returns the populated reporter.
+// It does not produce any output. Callers that want the CLI's colored
+// stdout rendering should call reporter.PrintResults() or use RunAllChecks.
+func Run(commands utils.Commands) *utils.Reporter {
 	reporter := utils.Reporter{}
 
 	env.CheckCommon(reporter.Component("Common Environment Variables"), commands.Language)
@@ -39,7 +42,13 @@ func RunAllChecks(commands utils.Commands) map[string][]string {
 		}
 	}
 
-	return reporter.PrintResults()
+	return &reporter
+}
+
+// RunAllChecks executes all configured checks and prints the colored summary
+// to stdout. Preserved as the CLI entry point; library callers should use Run.
+func RunAllChecks(commands utils.Commands) map[string][]string {
+	return Run(commands).PrintResults()
 }
 
 func SDKSetup(reporter *utils.ComponentReporter, commands utils.Commands) {

--- a/checks/utils/utils.go
+++ b/checks/utils/utils.go
@@ -120,7 +120,10 @@ func (r *Reporter) Component(name string) *ComponentReporter {
 	return c
 }
 
-func (r *Reporter) PrintResults() map[string][]string {
+// Results aggregates the checks, warnings, and errors across all components
+// without producing any output. Callers that want to render results their own
+// way (e.g. gcx) should use this; CLI callers should use PrintResults.
+func (r *Reporter) Results() map[string][]string {
 	res := make(map[string][]string)
 	var checks []string
 	for _, component := range r.components {
@@ -137,6 +140,14 @@ func (r *Reporter) PrintResults() map[string][]string {
 		errors = append(errors, component.Errors...)
 	}
 	res[ERRORS] = errors
+	return res
+}
+
+func (r *Reporter) PrintResults() map[string][]string {
+	res := r.Results()
+	checks := res[CHECKS]
+	warnings := res[WARNINGS]
+	errors := res[ERRORS]
 
 	if len(checks) > 0 {
 		green := color.New(color.FgGreen)

--- a/checks/utils/utils.go
+++ b/checks/utils/utils.go
@@ -122,7 +122,7 @@ func (r *Reporter) Component(name string) *ComponentReporter {
 
 // Results aggregates the checks, warnings, and errors across all components
 // without producing any output. Callers that want to render results their own
-// way (e.g. gcx) should use this; CLI callers should use PrintResults.
+// way should use this; CLI callers should use PrintResults.
 func (r *Reporter) Results() map[string][]string {
 	res := make(map[string][]string)
 	var checks []string

--- a/checks/utils/utils.go
+++ b/checks/utils/utils.go
@@ -25,10 +25,31 @@ type Commands struct {
 	Debug                 bool
 }
 
+var (
+	SupportedLanguages  = []string{"dotnet", "go", "java", "js", "python", "ruby", "php"}
+	SupportedComponents = []string{"sdk", "beyla", "alloy", "collector", "grafana-cloud"}
+)
+
+func Validate(c Commands) error {
+	if !slices.Contains(SupportedLanguages, c.Language) {
+		return fmt.Errorf("language %q not supported. Possible values: %s", c.Language, strings.Join(SupportedLanguages, ", "))
+	}
+	if len(c.Components) == 0 {
+		return fmt.Errorf("at least one component required. Possible values: %s", strings.Join(SupportedComponents, ", "))
+	}
+	for _, comp := range c.Components {
+		if !slices.Contains(SupportedComponents, strings.TrimSpace(comp)) {
+			return fmt.Errorf("component %q not supported. Possible values: %s", comp, strings.Join(SupportedComponents, ", "))
+		}
+	}
+	if c.Language == "js" && c.ManualInstrumentation && c.InstrumentationFile == "" {
+		return fmt.Errorf(`when manual-instrumentation is set, an instrumentation file is required (InstrumentationFile or -instrumentation-file=path/to/file.js)`)
+	}
+	return nil
+}
+
 func GetArguments() Commands {
-	command := Commands{}
-	args := os.Args[1:]
-	if len(args) < 1 {
+	if len(os.Args[1:]) < 1 {
 		fmt.Println(color.RedString("You must pass a language used for your instrumentation, such as -language=js"))
 		os.Exit(1)
 	}
@@ -47,48 +68,33 @@ func GetArguments() Commands {
 	collectorConfigPath := flag.String("collector-config-path", "", `Path to collector's config.yaml file. Required if using Collector and the config file is not in the same location as the otel-checker is being executed from. E.g. "-collector-config-path=src/inst/"`)
 	flag.Parse()
 
-	possibleLanguages := []string{"dotnet", "go", "java", "js", "python", "ruby", "php"}
-	if !slices.Contains(possibleLanguages, *languageValue) {
-		fmt.Println(color.RedString(fmt.Sprintf("Language %s not supported. Possible values: dotnet, go, java, js, python, ruby", *languageValue)))
+	var components []string
+	if *componentsString != "" {
+		components = strings.Split(*componentsString, ",")
+	}
+
+	command := Commands{
+		Language:              *languageValue,
+		Components:            components,
+		WebServer:             *webServer,
+		ManualInstrumentation: *manualInstrumentation,
+		InstrumentationFile:   *instrumentationFile,
+		PackageJsonPath:       *packageJsonPath,
+		CollectorConfigPath:   *collectorConfigPath,
+		Debug:                 *debug,
+	}
+
+	if err := Validate(command); err != nil {
+		fmt.Println(color.RedString(err.Error()))
 		os.Exit(1)
 	}
 
-	if *componentsString == "" {
-		fmt.Println(color.RedString(`Component flag required. Possible values: sdk, beyla, alloy, collector. E.g. -components="sdk,collector"`))
-		os.Exit(1)
+	if command.PackageJsonPath != "" && !strings.HasSuffix(command.PackageJsonPath, "/") {
+		command.PackageJsonPath = command.PackageJsonPath + "/"
 	}
-
-	possibleComponents := []string{"sdk", "beyla", "alloy", "collector", "grafana-cloud"}
-	components := strings.Split(*componentsString, ",")
-	for _, c := range components {
-		if !slices.Contains(possibleComponents, strings.Trim(c, " ")) {
-			fmt.Println(color.RedString(fmt.Sprintf(`Component %s not supported. Possible values: sdk, collector, beyla, alloy. E.g. -components="sdk,collector"`, c)))
-			os.Exit(1)
-		}
+	if command.CollectorConfigPath != "" && !strings.HasSuffix(command.CollectorConfigPath, "/") {
+		command.CollectorConfigPath = command.CollectorConfigPath + "/"
 	}
-
-	// javascript
-	if *languageValue == "js" && *instrumentationFile == "" && *manualInstrumentation {
-		fmt.Println(color.RedString(`When manual-instrumentation is being used, a instrumentation file is required. Remove "-manual-instrumentation" or "-instrumentation-file=path/to/file/file.js"`))
-		os.Exit(1)
-	}
-	if *packageJsonPath != "" && !strings.HasSuffix(*packageJsonPath, "/") {
-		*packageJsonPath = *packageJsonPath + "/"
-	}
-
-	// collector
-	if *collectorConfigPath != "" && !strings.HasSuffix(*collectorConfigPath, "/") {
-		*collectorConfigPath = *collectorConfigPath + "/"
-	}
-
-	command.Language = *languageValue
-	command.Components = components
-	command.WebServer = *webServer
-	command.ManualInstrumentation = *manualInstrumentation
-	command.InstrumentationFile = *instrumentationFile
-	command.PackageJsonPath = *packageJsonPath
-	command.CollectorConfigPath = *collectorConfigPath
-	command.Debug = *debug
 	return command
 }
 

--- a/checks/utils/utils_test.go
+++ b/checks/utils/utils_test.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      Commands
+		wantErr string
+	}{
+		{
+			name: "valid go sdk",
+			in:   Commands{Language: "go", Components: []string{"sdk"}},
+		},
+		{
+			name: "valid js collector with trimmed component",
+			in:   Commands{Language: "js", Components: []string{"sdk", " collector"}},
+		},
+		{
+			name:    "unsupported language",
+			in:      Commands{Language: "rust", Components: []string{"sdk"}},
+			wantErr: `language "rust" not supported`,
+		},
+		{
+			name:    "empty language",
+			in:      Commands{Components: []string{"sdk"}},
+			wantErr: `language "" not supported`,
+		},
+		{
+			name:    "no components",
+			in:      Commands{Language: "go"},
+			wantErr: "at least one component required",
+		},
+		{
+			name:    "unsupported component",
+			in:      Commands{Language: "go", Components: []string{"sdk", "bogus"}},
+			wantErr: `component "bogus" not supported`,
+		},
+		{
+			name: "js manual without instrumentation file",
+			in: Commands{
+				Language:              "js",
+				Components:            []string{"sdk"},
+				ManualInstrumentation: true,
+			},
+			wantErr: "manual-instrumentation is set",
+		},
+		{
+			name: "js manual with instrumentation file",
+			in: Commands{
+				Language:              "js",
+				Components:            []string{"sdk"},
+				ManualInstrumentation: true,
+				InstrumentationFile:   "src/inst.js",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.in)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() returned unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() returned nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/checks/utils/utils_test.go
+++ b/checks/utils/utils_test.go
@@ -3,7 +3,24 @@ package utils
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestReporterResults(t *testing.T) {
+	r := &Reporter{}
+	sdk := r.Component("SDK")
+	sdk.AddSuccessfulCheck("foo")
+	sdk.AddWarning("bar")
+	collector := r.Component("Collector")
+	collector.AddError("baz")
+
+	got := r.Results()
+
+	assert.ElementsMatch(t, []string{"SDK: foo"}, got[CHECKS])
+	assert.ElementsMatch(t, []string{"SDK: bar"}, got[WARNINGS])
+	assert.ElementsMatch(t, []string{"Collector: baz"}, got[ERRORS])
+}
 
 func TestValidate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Changes:

- split PrintResults() into two methods:
     - `Results() map[string][]string`: pure data aggregation, no I/O. This is what library callers (gcx) will use.
     - `PrintResults()`: delegates to `Results()` then prints colored stdout. CLI behavior unchanged.
[checks/checks.go](vscode-webview://0ie029b1tvcno922r84pqfq06utiq7v68n8rk2piiq6gvbku7o7k/checks/checks.go) 
- split `RunAllChecks` into:
    - `Run(commands utils.Commands) *utils.Reporter`: runs all checks, returns the populated reporter. No printing.
    - `RunAllChecks(commands utils.Commands) map[string][]string`: one-liner CLI wrapper `Run(commands).PrintResults()`. Same signature, same behavior.

Changes on top of #325