### PR TITLE
improve results format

### DIFF
--- a/checks/checks.go
+++ b/checks/checks.go
@@ -16,8 +16,8 @@ import (
 )
 
 // Run executes all configured checks and returns the populated reporter.
-// It does not produce any output. Callers that want the CLI's colored
-// stdout rendering should call reporter.PrintResults() or use RunAllChecks.
+// It does not produce any output; pair it with output.Render or
+// reporter.Results() to display or consume the results.
 func Run(commands utils.Commands) *utils.Reporter {
 	reporter := utils.Reporter{}
 
@@ -43,12 +43,6 @@ func Run(commands utils.Commands) *utils.Reporter {
 	}
 
 	return &reporter
-}
-
-// RunAllChecks executes all configured checks and prints the colored summary
-// to stdout. Preserved as the CLI entry point; library callers should use Run.
-func RunAllChecks(commands utils.Commands) map[string][]string {
-	return Run(commands).PrintResults()
 }
 
 func SDKSetup(reporter *utils.ComponentReporter, commands utils.Commands) {

--- a/checks/output/output.go
+++ b/checks/output/output.go
@@ -1,0 +1,106 @@
+// Package output renders a Reporter to a chosen format. Supported formats
+// are "text" (colored stdout), "json", and "yaml". Library callers that
+// want full control can implement Renderer themselves and call its Render
+// method, or read Reporter.Results() and render manually.
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/grafana/otel-checker/checks/utils"
+
+	"github.com/fatih/color"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	FormatText = "text"
+	FormatJSON = "json"
+	FormatYAML = "yaml"
+)
+
+// Renderer turns a Reporter into bytes written to w. Implementations should
+// be cheap to construct; pass options as struct fields.
+type Renderer interface {
+	Render(w io.Writer, reporter *utils.Reporter) error
+}
+
+// TextRenderer prints a human-readable summary. ANSI color codes are emitted
+// when fatih/color's runtime detection decides the output is a terminal
+// (respects NO_COLOR, FORCE_COLOR, and isatty checks).
+type TextRenderer struct{}
+
+func (TextRenderer) Render(w io.Writer, reporter *utils.Reporter) error {
+	res := reporter.Results()
+	checks := res[utils.CHECKS]
+	warnings := res[utils.WARNINGS]
+	errors := res[utils.ERRORS]
+
+	green := color.New(color.FgGreen)
+	yellow := color.New(color.FgYellow)
+	red := color.New(color.FgRed)
+
+	if len(checks) > 0 {
+		_, _ = green.Fprintf(w, "\n%d Successful Check(s)\n", len(checks))
+		for _, m := range checks {
+			_, _ = green.Fprintf(w, "✔ %s \n", m)
+		}
+	}
+	if len(warnings) > 0 {
+		_, _ = yellow.Fprintf(w, "\n%d Warning(s)\n", len(warnings))
+		for _, m := range warnings {
+			_, _ = yellow.Fprintf(w, "• %s \n", m)
+		}
+	}
+	if len(errors) > 0 {
+		_, _ = red.Fprintf(w, "\n%d Error(s)\n", len(errors))
+		for _, m := range errors {
+			_, _ = red.Fprintf(w, "✖ %s \n", m)
+		}
+	}
+	return nil
+}
+
+// JSONRenderer emits Reporter.Results() as JSON.
+type JSONRenderer struct {
+	// Indent is the per-level indent string. Empty means compact output.
+	Indent string
+}
+
+func (j JSONRenderer) Render(w io.Writer, reporter *utils.Reporter) error {
+	enc := json.NewEncoder(w)
+	if j.Indent != "" {
+		enc.SetIndent("", j.Indent)
+	}
+	return enc.Encode(reporter.Results())
+}
+
+// YAMLRenderer emits Reporter.Results() as YAML.
+type YAMLRenderer struct{}
+
+func (YAMLRenderer) Render(w io.Writer, reporter *utils.Reporter) error {
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	defer func() { _ = enc.Close() }()
+	return enc.Encode(reporter.Results())
+}
+
+// Render is a convenience that picks a Renderer based on the format string
+// and writes to w. An empty format defaults to text.
+func Render(w io.Writer, reporter *utils.Reporter, format string) error {
+	if format == "" {
+		format = FormatText
+	}
+	switch format {
+	case FormatText:
+		return TextRenderer{}.Render(w, reporter)
+	case FormatJSON:
+		return JSONRenderer{Indent: "  "}.Render(w, reporter)
+	case FormatYAML:
+		return YAMLRenderer{}.Render(w, reporter)
+	default:
+		return fmt.Errorf("format %q not supported. Possible values: text, json, yaml", format)
+	}
+}

--- a/checks/output/output_test.go
+++ b/checks/output/output_test.go
@@ -1,0 +1,100 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/grafana/otel-checker/checks/utils"
+
+	"github.com/fatih/color"
+	"go.yaml.in/yaml/v3"
+)
+
+func newReporter(t *testing.T) *utils.Reporter {
+	t.Helper()
+	r := &utils.Reporter{}
+	sdk := r.Component("SDK")
+	sdk.AddSuccessfulCheck("foo")
+	sdk.AddWarning("bar")
+	collector := r.Component("Collector")
+	collector.AddError("baz")
+	return r
+}
+
+func TestRenderJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, newReporter(t), FormatJSON); err != nil {
+		t.Fatalf("Render(json): %v", err)
+	}
+	var got map[string][]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if len(got[utils.CHECKS]) != 1 || !strings.Contains(got[utils.CHECKS][0], "foo") {
+		t.Errorf("checks = %v, want one entry containing %q", got[utils.CHECKS], "foo")
+	}
+	if len(got[utils.WARNINGS]) != 1 || !strings.Contains(got[utils.WARNINGS][0], "bar") {
+		t.Errorf("warnings = %v, want one entry containing %q", got[utils.WARNINGS], "bar")
+	}
+	if len(got[utils.ERRORS]) != 1 || !strings.Contains(got[utils.ERRORS][0], "baz") {
+		t.Errorf("errors = %v, want one entry containing %q", got[utils.ERRORS], "baz")
+	}
+}
+
+func TestRenderYAML(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, newReporter(t), FormatYAML); err != nil {
+		t.Fatalf("Render(yaml): %v", err)
+	}
+	var got map[string][]string
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, buf.String())
+	}
+	if len(got[utils.CHECKS]) != 1 {
+		t.Errorf("checks = %v, want length 1", got[utils.CHECKS])
+	}
+}
+
+func TestRenderText(t *testing.T) {
+	// Disable color codes so substring assertions don't trip on ANSI escapes.
+	saved := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = saved })
+
+	var buf bytes.Buffer
+	if err := Render(&buf, newReporter(t), FormatText); err != nil {
+		t.Fatalf("Render(text): %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"1 Successful Check", "SDK: foo", "1 Warning", "SDK: bar", "1 Error", "Collector: baz"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q.\nGot:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderDefaultsToText(t *testing.T) {
+	saved := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = saved })
+
+	var buf bytes.Buffer
+	if err := Render(&buf, newReporter(t), ""); err != nil {
+		t.Fatalf("Render(empty format): %v", err)
+	}
+	if !strings.Contains(buf.String(), "1 Successful Check") {
+		t.Errorf("empty format did not produce text output. Got:\n%s", buf.String())
+	}
+}
+
+func TestRenderUnknownFormat(t *testing.T) {
+	err := Render(&bytes.Buffer{}, newReporter(t), "xml")
+	if err == nil {
+		t.Fatal("Render(xml) returned nil, want error")
+	}
+	if !strings.Contains(err.Error(), `"xml" not supported`) {
+		t.Errorf("error = %q, want it to mention xml", err.Error())
+	}
+}

--- a/checks/utils/utils.go
+++ b/checks/utils/utils.go
@@ -23,11 +23,13 @@ type Commands struct {
 	PackageJsonPath       string
 	CollectorConfigPath   string
 	Debug                 bool
+	Format                string
 }
 
 var (
 	SupportedLanguages  = []string{"dotnet", "go", "java", "js", "python", "ruby", "php"}
 	SupportedComponents = []string{"sdk", "beyla", "alloy", "collector", "grafana-cloud"}
+	SupportedFormats    = []string{"text", "json", "yaml"}
 )
 
 func Validate(c Commands) error {
@@ -45,6 +47,9 @@ func Validate(c Commands) error {
 	if c.Language == "js" && c.ManualInstrumentation && c.InstrumentationFile == "" {
 		return fmt.Errorf(`when manual-instrumentation is set, an instrumentation file is required (InstrumentationFile or -instrumentation-file=path/to/file.js)`)
 	}
+	if c.Format != "" && !slices.Contains(SupportedFormats, c.Format) {
+		return fmt.Errorf("format %q not supported. Possible values: %s", c.Format, strings.Join(SupportedFormats, ", "))
+	}
 	return nil
 }
 
@@ -59,6 +64,7 @@ func GetArguments() Commands {
 	manualInstrumentation := flag.Bool("manual-instrumentation", false, "Provide if your application is using manual instrumentation")
 	debug := flag.Bool("debug", false, "Output debug information")
 	webServer := flag.Bool("web-server", false, "Set if you would like the results served in a web server in addition to console output")
+	format := flag.String("format", "text", "Output format. Possible values: text, json, yaml")
 
 	// javascript
 	instrumentationFile := flag.String("instrumentation-file", "", `Name (including path) to instrumentation file. Required if using manual-instrumentation. E.g."-instrumentation-file=src/inst/instrumentation.js"`)
@@ -82,6 +88,7 @@ func GetArguments() Commands {
 		PackageJsonPath:       *packageJsonPath,
 		CollectorConfigPath:   *collectorConfigPath,
 		Debug:                 *debug,
+		Format:                *format,
 	}
 
 	if err := Validate(command); err != nil {
@@ -140,36 +147,6 @@ func (r *Reporter) Results() map[string][]string {
 		errors = append(errors, component.Errors...)
 	}
 	res[ERRORS] = errors
-	return res
-}
-
-func (r *Reporter) PrintResults() map[string][]string {
-	res := r.Results()
-	checks := res[CHECKS]
-	warnings := res[WARNINGS]
-	errors := res[ERRORS]
-
-	if len(checks) > 0 {
-		green := color.New(color.FgGreen)
-		_, _ = green.Printf("\n%d Successful Check(s)\n", len(checks))
-		for _, m := range checks {
-			_, _ = green.Printf("✔ %s \n", m)
-		}
-	}
-	if len(warnings) > 0 {
-		yellow := color.New(color.FgYellow)
-		_, _ = yellow.Printf("\n%d Warning(s)\n", len(warnings))
-		for _, m := range warnings {
-			_, _ = yellow.Printf("• %s \n", m)
-		}
-	}
-	if len(errors) > 0 {
-		red := color.New(color.FgRed)
-		_, _ = red.Printf("\n%d Error(s)\n", len(errors))
-		for _, m := range errors {
-			_, _ = red.Printf("✖ %s \n", m)
-		}
-	}
 	return res
 }
 

--- a/main.go
+++ b/main.go
@@ -1,22 +1,30 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/grafana/otel-checker/checks"
+	"github.com/grafana/otel-checker/checks/output"
 	"github.com/grafana/otel-checker/checks/utils"
 	"github.com/grafana/otel-checker/checks/webserver"
 )
 
 func main() {
 	commands := utils.GetArguments()
-	messages := checks.RunAllChecks(commands)
+	reporter := checks.Run(commands)
+
+	if err := output.Render(os.Stdout, reporter, commands.Format); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	if !commands.WebServer {
 		return
 	}
 
-	if err := webserver.Run(":8080", messages); err != nil {
+	if err := webserver.Run(":8080", reporter.Results()); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Previously the tests were always returning text already printed with colors.
This PR allows different results formats (to match gcx) and the caller can create their own render to match the tool that is calling.
If using otel-checker directly, it still print (with color) as previously.