### PR TITLE
fix exporter type

### DIFF
--- a/checks/env/common.go
+++ b/checks/env/common.go
@@ -131,14 +131,17 @@ func exporterEnvVar(key string, name string) EnvVar {
 		Required:     false,
 		DefaultValue: "otlp",
 		Validator: func(value string, language string, reporter *utils.ComponentReporter) {
-			if value == "none" {
-				reporter.AddError(fmt.Sprintf("The value of %s cannot be 'none'. Change the value to 'otlp' or leave it unset", key))
-			} else {
-				if value == "" {
-					reporter.AddSuccessfulCheck(fmt.Sprintf("%s is unset, with a default value of 'otlp'", key))
-				} else {
-					reporter.AddSuccessfulCheck(fmt.Sprintf("The value of %s is set to '%s' (default value)", key, value))
-				}
+			switch value {
+			case "":
+				reporter.AddSuccessfulCheck(fmt.Sprintf("%s is unset, with a default value of 'otlp'", key))
+			case "otlp":
+				reporter.AddSuccessfulCheck(fmt.Sprintf("The value of %s is set to 'otlp' (default value)", key))
+			case "console":
+				reporter.AddSuccessfulCheck(fmt.Sprintf("The value of %s is set to 'console'", key))
+			case "none":
+				reporter.AddError(fmt.Sprintf("The value of %s cannot be 'none'. Change the value to 'otlp' or 'console', or leave it unset", key))
+			default:
+				reporter.AddError(fmt.Sprintf("The value of %s must be 'otlp' or 'console' (or unset). Got '%s'", key, value))
 			}
 		},
 		Description: name + " exporter configuration",

--- a/checks/env/common_test.go
+++ b/checks/env/common_test.go
@@ -198,9 +198,38 @@ func TestCheckExporterEnvVars(t *testing.T) {
 			}),
 			Language: "python",
 			ExpectedErrors: []string{
-				"The value of OTEL_METRICS_EXPORTER cannot be 'none'. Change the value to 'otlp' or leave it unset",
-				"The value of OTEL_TRACES_EXPORTER cannot be 'none'. Change the value to 'otlp' or leave it unset",
-				"The value of OTEL_LOGS_EXPORTER cannot be 'none'. Change the value to 'otlp' or leave it unset",
+				"The value of OTEL_METRICS_EXPORTER cannot be 'none'. Change the value to 'otlp' or 'console', or leave it unset",
+				"The value of OTEL_TRACES_EXPORTER cannot be 'none'. Change the value to 'otlp' or 'console', or leave it unset",
+				"The value of OTEL_LOGS_EXPORTER cannot be 'none'. Change the value to 'otlp' or 'console', or leave it unset",
+			},
+			IgnoreChecks: true,
+		},
+		{
+			Name: "exporters set to console",
+			EnvVars: correctWith(map[string]string{
+				"OTEL_METRICS_EXPORTER": "console",
+				"OTEL_TRACES_EXPORTER":  "console",
+				"OTEL_LOGS_EXPORTER":    "console",
+			}),
+			Language: "python",
+			ExpectedChecks: []string{
+				"The value of OTEL_METRICS_EXPORTER is set to 'console'",
+				"The value of OTEL_TRACES_EXPORTER is set to 'console'",
+				"The value of OTEL_LOGS_EXPORTER is set to 'console'",
+			},
+		},
+		{
+			Name: "exporters set to an unsupported value",
+			EnvVars: correctWith(map[string]string{
+				"OTEL_METRICS_EXPORTER": "prometheus",
+				"OTEL_TRACES_EXPORTER":  "jaeger",
+				"OTEL_LOGS_EXPORTER":    "syslog",
+			}),
+			Language: "python",
+			ExpectedErrors: []string{
+				"The value of OTEL_METRICS_EXPORTER must be 'otlp' or 'console' (or unset). Got 'prometheus'",
+				"The value of OTEL_TRACES_EXPORTER must be 'otlp' or 'console' (or unset). Got 'jaeger'",
+				"The value of OTEL_LOGS_EXPORTER must be 'otlp' or 'console' (or unset). Got 'syslog'",
 			},
 			IgnoreChecks: true,
 		},


### PR DESCRIPTION
The valid exporters are `otlp`, `console` or `none`, but we don't recommend `none`. Previously it would accept anything that was not `none`, such as `foo`.