### PR TITLE
fix: Make named components valid config

### DIFF
--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -50,6 +50,8 @@ type exporterConfig struct {
 	Auth     map[string]interface{} `yaml:"auth"`
 }
 
+var otlpHTTPGrafanaEndpointPattern = regexp.MustCompile(`https://.+\.grafana\.net/otlp`)
+
 func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) {
 	filePath := filepath.Join(configPath, "config.yaml")
 	yamlFile, err := os.ReadFile(filePath)
@@ -124,8 +126,7 @@ func checkOTLPReceiverHTTPProtocol(reporter *utils.ComponentReporter, receivers 
 func checkOTLPHTTPExporterEndpoint(reporter *utils.ComponentReporter, exporters map[string]exporterConfig) {
 	ids := otlpHTTPExporterIDs(exporters)
 	for _, id := range ids {
-		match, _ := regexp.MatchString("https:\\/\\/.+\\.grafana\\.net\\/otlp", exporters[id].Endpoint)
-		if match {
+		if otlpHTTPGrafanaEndpointPattern.MatchString(exporters[id].Endpoint) {
 			reporter.AddSuccessfulCheck(fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp", id))
 			return
 		}

--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"slices"
+	"sort"
 	"strings"
 
 	"github.com/grafana/otel-checker/checks/utils"
@@ -18,18 +18,9 @@ func CheckCollectorSetup(reporter *utils.ComponentReporter, language string, con
 }
 
 type configFile struct {
-	Receivers struct {
-		Otlp struct {
-			Protocols map[string]any `yaml:"protocols"`
-		} `yaml:"otlp"`
-	} `yaml:"receivers"`
-	Exporters struct {
-		Otlphttp struct {
-			Endpoint string                 `yaml:"endpoint"`
-			Auth     map[string]interface{} `yaml:"auth"`
-		} `yaml:"otlphttp"`
-	} `yaml:"exporters"`
-	Service struct {
+	Receivers map[string]receiverConfig `yaml:"receivers"`
+	Exporters map[string]exporterConfig `yaml:"exporters"`
+	Service   struct {
 		Pipelines struct {
 			Traces struct {
 				Receivers  []string `yaml:"receivers"`
@@ -50,6 +41,15 @@ type configFile struct {
 	} `yaml:"service"`
 }
 
+type receiverConfig struct {
+	Protocols map[string]any `yaml:"protocols"`
+}
+
+type exporterConfig struct {
+	Endpoint string                 `yaml:"endpoint"`
+	Auth     map[string]interface{} `yaml:"auth"`
+}
+
 func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) {
 	filePath := filepath.Join(configPath, "config.yaml")
 	yamlFile, err := os.ReadFile(filePath)
@@ -65,61 +65,124 @@ func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) 
 			return
 		}
 
-		if c.Receivers.Otlp.Protocols["http"] == nil {
-			reporter.AddWarningWithExplain("collector.receivers.http-protocol-missing",
-				"The value of receivers > otlp > protocols > http is nil. Make sure the key exists on your config.yaml")
-		}
+		checkOTLPReceiverHTTPProtocol(reporter, c.Receivers)
 
-		match, _ := regexp.MatchString("https:\\/\\/.+\\.grafana\\.net\\/otlp", c.Exporters.Otlphttp.Endpoint)
-		if match {
-			reporter.AddSuccessfulCheck("Value of exporter > otlphttp > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
-		} else {
-			if strings.Contains(c.Exporters.Otlphttp.Endpoint, "localhost") {
-				reporter.AddWarningWithExplain("collector.endpoint.localhost",
-					"Value of exporter > otlphttp > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance")
-			} else {
-				reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
-					"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
-			}
-		}
+		checkOTLPHTTPExporterEndpoint(reporter, c.Exporters)
 
 		// Traces
-		if slices.Contains(c.Service.Pipelines.Traces.Exporters, "otlphttp") {
+		if containsOTLPHTTPExporter(c.Service.Pipelines.Traces.Exporters) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > exporters on config.yaml contains otlphttp")
 		} else {
 			reporter.AddWarningWithExplain("collector.pipelines.traces-otlphttp-missing",
 				"Value of service > pipelines > traces > exporters on config.yaml does not contain otlphttp")
 		}
-		if slices.Contains(c.Service.Pipelines.Traces.Receivers, "otlp") {
+		if containsOTLPReceiver(c.Service.Pipelines.Traces.Receivers) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml contains otlp")
 		} else {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml does not contain otlp")
 		}
 
 		// Logs
-		if slices.Contains(c.Service.Pipelines.Logs.Exporters, "otlphttp") {
+		if containsOTLPHTTPExporter(c.Service.Pipelines.Logs.Exporters) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > exporters on config.yaml contains otlphttp")
 		} else {
 			reporter.AddWarningWithExplain("collector.pipelines.logs-otlphttp-missing",
 				"Value of service > pipelines > logs > exporters on config.yaml does not contain otlphttp")
 		}
-		if slices.Contains(c.Service.Pipelines.Logs.Receivers, "otlp") {
+		if containsOTLPReceiver(c.Service.Pipelines.Logs.Receivers) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml contains otlp")
 		} else {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml does not contain otlp")
 		}
 
 		// Metrics
-		if slices.Contains(c.Service.Pipelines.Metrics.Exporters, "otlphttp") {
+		if containsOTLPHTTPExporter(c.Service.Pipelines.Metrics.Exporters) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp")
 		} else {
 			reporter.AddWarningWithExplain("collector.pipelines.metrics-otlphttp-missing",
 				"Value of service > pipelines > metrics > exporters on config.yaml does not contain otlphttp")
 		}
-		if slices.Contains(c.Service.Pipelines.Metrics.Receivers, "otlp") {
+		if containsOTLPReceiver(c.Service.Pipelines.Metrics.Receivers) {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml contains otlp")
 		} else {
 			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp")
 		}
 	}
+}
+
+func checkOTLPReceiverHTTPProtocol(reporter *utils.ComponentReporter, receivers map[string]receiverConfig) {
+	for _, id := range componentIDsWithType(receivers, "otlp") {
+		if receivers[id].Protocols["http"] != nil {
+			return
+		}
+	}
+
+	reporter.AddWarningWithExplain("collector.receivers.http-protocol-missing",
+		"The value of receivers > otlp > protocols > http is nil. Make sure the key exists on your config.yaml")
+}
+
+func checkOTLPHTTPExporterEndpoint(reporter *utils.ComponentReporter, exporters map[string]exporterConfig) {
+	ids := otlpHTTPExporterIDs(exporters)
+	for _, id := range ids {
+		match, _ := regexp.MatchString("https:\\/\\/.+\\.grafana\\.net\\/otlp", exporters[id].Endpoint)
+		if match {
+			reporter.AddSuccessfulCheck(fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp", id))
+			return
+		}
+	}
+
+	for _, id := range ids {
+		if strings.Contains(exporters[id].Endpoint, "localhost") {
+			reporter.AddWarningWithExplain("collector.endpoint.localhost",
+				fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance", id))
+			return
+		}
+	}
+
+	reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
+		"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
+}
+
+func otlpHTTPExporterIDs(exporters map[string]exporterConfig) []string {
+	return componentIDsWithType(exporters, "otlphttp", "otlp_http")
+}
+
+func componentIDsWithType[T any](components map[string]T, types ...string) []string {
+	ids := make([]string, 0, len(components))
+	for id := range components {
+		if componentIDHasType(id, types...) {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func containsOTLPHTTPExporter(exporters []string) bool {
+	for _, exporter := range exporters {
+		if componentIDHasType(exporter, "otlphttp", "otlp_http") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsOTLPReceiver(receivers []string) bool {
+	for _, receiver := range receivers {
+		if componentIDHasType(receiver, "otlp") {
+			return true
+		}
+	}
+	return false
+}
+
+func componentIDHasType(id string, types ...string) bool {
+	componentType, _, _ := strings.Cut(id, "/")
+	componentType = strings.ToLower(componentType)
+	for _, t := range types {
+		if componentType == t {
+			return true
+		}
+	}
+	return false
 }

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -71,6 +71,88 @@ service:
 			},
 		},
 		{
+			name: "Valid Grafana Cloud configuration with named receiver and exporter",
+			configYAML: `
+receivers:
+  otlp/app:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  otlphttp/grafana_cloud:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+  otlphttp/local:
+    endpoint: http://localhost:4318
+service:
+  pipelines:
+    traces:
+      receivers: [otlp/app]
+      processors: []
+      exporters: [otlphttp/grafana_cloud, otlphttp/local]
+    logs:
+      receivers: [otlp/app]
+      processors: []
+      exporters: [otlphttp/grafana_cloud]
+    metrics:
+      receivers: [otlp/app]
+      processors: []
+      exporters: [otlphttp/grafana_cloud]
+`,
+			expectedErrors:   []string{},
+			expectedWarnings: []string{},
+			expectedChecks: []string{
+				"Value of exporter > otlphttp/grafana_cloud > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > logs > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > metrics > receivers on config.yaml contains otlp",
+			},
+		},
+		{
+			name: "Valid Grafana Cloud configuration with legacy underscore exporter type",
+			configYAML: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  otlp_http/grafana_cloud:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp_http/grafana_cloud]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp_http/grafana_cloud]
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp_http/grafana_cloud]
+`,
+			expectedErrors:   []string{},
+			expectedWarnings: []string{},
+			expectedChecks: []string{
+				"Value of exporter > otlp_http/grafana_cloud > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > logs > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > metrics > receivers on config.yaml contains otlp",
+			},
+		},
+		{
 			name: "Localhost configuration",
 			configYAML: `
 receivers:

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -153,6 +153,42 @@ service:
 			},
 		},
 		{
+			name: "Invalid Grafana Cloud endpoint with named otlp_http exporter",
+			configYAML: `
+receivers:
+  otlp:
+    protocols:
+      grpc: ""
+      http: ""
+exporters:
+  otlp_http/invalid:
+    endpoint: invalid_endpoint
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [otlp_http/invalid]
+    logs:
+      receivers: [otlp]
+      exporters: [otlp_http/invalid]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp_http/invalid]
+`,
+			expectedErrors: []string{
+				"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+			},
+			expectedWarnings: []string{},
+			expectedChecks: []string{
+				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > logs > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > metrics > receivers on config.yaml contains otlp",
+			},
+		},
+		{
 			name: "Localhost configuration",
 			configYAML: `
 receivers:


### PR DESCRIPTION
While testing `gcx instrumentation check`, I'm getting warnings for a config file that has things like this:

```yaml
exporters:
  debug:
    verbosity: detailed
  otlp_http/grafana_cloud:
    endpoint: https://otlp-gateway-prod-sa-east-1.grafana.net/otlp
    auth:
      authenticator: basicauth/grafana_cloud
  otlp_http/prometheus:
    endpoint: http://prometheus:9090/api/v1/otlp
  otlp_http/loki:
    endpoint: http://loki:3100/otlp
  otlp_http/tempo:
    endpoint: http://tempo:4318
  otlp_http/pyroscope:
    endpoint: http://pyroscope:4040
service:
  pipelines:
    metrics:
      receivers: [otlp, prometheus]
      processors: [resource/home_monitoring, batch]
      exporters: [otlp_http/grafana_cloud, otlp_http/prometheus]
    logs:
      receivers: [otlp, receiver_creator]
      processors: [resource/home_monitoring, batch]
      exporters: [otlp_http/loki, otlp_http/grafana_cloud]
    traces:
      receivers: [otlp]
      processors: [resource/home_monitoring, batch]
      exporters: [otlp_http/grafana_cloud, otlp_http/tempo]
```

Warnings:
```
FAIL    Collector    Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp
WARN    Collector    Value of service > pipelines > traces > exporters on config.yaml does not contain otlphttp
WARN    Collector    Value of service > pipelines > logs > exporters on config.yaml does not contain otlphttp
WARN    Collector    Value of service > pipelines > metrics > exporters on config.yaml does not contain otlphttp
```
I believe these are valid configurations, right?