### PR TITLE
update collector config file path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ flint: fixed: gofmt — commit before pushing | partial: cargo-clippy
 ```bash
 # Per-component verbs
 otel-checker check sdk           --language=<lang> [--manual-instrumentation ...]
-otel-checker check collector     [--collector-config-path=<path>]
+otel-checker check collector     [--collector-config-path=<file>]
 otel-checker check beyla         --language=<lang>
 otel-checker check alloy         --language=<lang>
 otel-checker check grafana-cloud --language=<lang>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flag set on each subcommand.
 # Single-component checks
 otel-checker check sdk --language=js
 otel-checker check sdk --language=java --manual-instrumentation
-otel-checker check collector --collector-config-path=./otel/
+otel-checker check collector --collector-config-path=./otel/config.yaml
 otel-checker check grafana-cloud --language=python
 
 # Multi-component (positional, comma-separated, no spaces)

--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -3,7 +3,6 @@ package collector
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -50,76 +49,96 @@ type configFile struct {
 	} `yaml:"service"`
 }
 
+// checkCollectorConfig reads the Collector configuration file and runs the
+// downstream checks against it. configPath, when non-empty, must be the full
+// path to the file the user wants checked. When configPath is empty, the
+// checker falls back to config.yaml then config.yml in the current
+// working directory.
 func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) {
-	filePath := filepath.Join(configPath, "config.yaml")
-	yamlFile, err := os.ReadFile(filePath)
-	if err != nil {
-		reporter.AddErrorWithExplain("collector.config.unreadable",
-			fmt.Sprintf("Could not check file %s: %s", filePath, err))
+	var candidates []string
+	if configPath != "" {
+		candidates = []string{configPath}
 	} else {
-		var c configFile
-		err = yaml.Unmarshal([]byte(yamlFile), &c)
-		if err != nil {
-			reporter.AddErrorWithExplain("collector.config.parse-error",
-				fmt.Sprintf("Could not parse file %s: %s", filePath, err))
-			return
+		candidates = []string{"config.yaml", "config.yml"}
+	}
+	var (
+		filePath string
+		yamlFile []byte
+	)
+	for _, p := range candidates {
+		b, err := os.ReadFile(p)
+		if err == nil {
+			filePath = p
+			yamlFile = b
+			break
 		}
+	}
+	if yamlFile == nil {
+		reporter.AddErrorWithExplain("collector.config.unreadable",
+			fmt.Sprintf("Could not find a Collector config file. Tried: %s", strings.Join(candidates, ", ")))
+		return
+	}
+	var c configFile
+	if err := yaml.Unmarshal(yamlFile, &c); err != nil {
+		reporter.AddErrorWithExplain("collector.config.parse-error",
+			fmt.Sprintf("Could not parse file %s: %s", filePath, err))
+		return
+	}
 
-		if c.Receivers.Otlp.Protocols["http"] == nil {
-			reporter.AddWarningWithExplain("collector.receivers.http-protocol-missing",
-				"The value of receivers > otlp > protocols > http is nil. Make sure the key exists on your config.yaml")
-		}
+	if c.Receivers.Otlp.Protocols["http"] == nil {
+		reporter.AddWarningWithExplain("collector.receivers.http-protocol-missing",
+			"The value of receivers > otlp > protocols > http is nil. Make sure the key exists on your config.yaml")
+	}
 
-		match, _ := regexp.MatchString("https:\\/\\/.+\\.grafana\\.net\\/otlp", c.Exporters.Otlphttp.Endpoint)
-		if match {
-			reporter.AddSuccessfulCheck("Value of exporter > otlphttp > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
+	match, _ := regexp.MatchString("https:\\/\\/.+\\.grafana\\.net\\/otlp", c.Exporters.Otlphttp.Endpoint)
+	if match {
+		reporter.AddSuccessfulCheck("Value of exporter > otlphttp > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
+	} else {
+		if strings.Contains(c.Exporters.Otlphttp.Endpoint, "localhost") {
+			reporter.AddWarningWithExplain("collector.endpoint.localhost",
+				"Value of exporter > otlphttp > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance")
 		} else {
-			if strings.Contains(c.Exporters.Otlphttp.Endpoint, "localhost") {
-				reporter.AddWarningWithExplain("collector.endpoint.localhost",
-					"Value of exporter > otlphttp > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance")
-			} else {
-				reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
-					"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
-			}
+			reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
+				"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
 		}
+	}
 
-		// Traces
-		if slices.Contains(c.Service.Pipelines.Traces.Exporters, "otlphttp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > exporters on config.yaml contains otlphttp")
-		} else {
-			reporter.AddWarningWithExplain("collector.pipelines.traces-otlphttp-missing",
-				"Value of service > pipelines > traces > exporters on config.yaml does not contain otlphttp")
-		}
-		if slices.Contains(c.Service.Pipelines.Traces.Receivers, "otlp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml contains otlp")
-		} else {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml does not contain otlp")
-		}
+	// Traces
+	if slices.Contains(c.Service.Pipelines.Traces.Exporters, "otlphttp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > traces > exporters on config.yaml contains otlphttp")
+	} else {
+		reporter.AddWarningWithExplain("collector.pipelines.traces-otlphttp-missing",
+			"Value of service > pipelines > traces > exporters on config.yaml does not contain otlphttp")
+	}
+	if slices.Contains(c.Service.Pipelines.Traces.Receivers, "otlp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml contains otlp")
+	} else {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml does not contain otlp")
+	}
 
-		// Logs
-		if slices.Contains(c.Service.Pipelines.Logs.Exporters, "otlphttp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > exporters on config.yaml contains otlphttp")
-		} else {
-			reporter.AddWarningWithExplain("collector.pipelines.logs-otlphttp-missing",
-				"Value of service > pipelines > logs > exporters on config.yaml does not contain otlphttp")
-		}
-		if slices.Contains(c.Service.Pipelines.Logs.Receivers, "otlp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml contains otlp")
-		} else {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml does not contain otlp")
-		}
+	// Logs
+	if slices.Contains(c.Service.Pipelines.Logs.Exporters, "otlphttp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > logs > exporters on config.yaml contains otlphttp")
+	} else {
+		reporter.AddWarningWithExplain("collector.pipelines.logs-otlphttp-missing",
+			"Value of service > pipelines > logs > exporters on config.yaml does not contain otlphttp")
+	}
+	if slices.Contains(c.Service.Pipelines.Logs.Receivers, "otlp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml contains otlp")
+	} else {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml does not contain otlp")
+	}
 
-		// Metrics
-		if slices.Contains(c.Service.Pipelines.Metrics.Exporters, "otlphttp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp")
-		} else {
-			reporter.AddWarningWithExplain("collector.pipelines.metrics-otlphttp-missing",
-				"Value of service > pipelines > metrics > exporters on config.yaml does not contain otlphttp")
-		}
-		if slices.Contains(c.Service.Pipelines.Metrics.Receivers, "otlp") {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml contains otlp")
-		} else {
-			reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp")
-		}
+	// Metrics
+	if slices.Contains(c.Service.Pipelines.Metrics.Exporters, "otlphttp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp")
+	} else {
+		reporter.AddWarningWithExplain("collector.pipelines.metrics-otlphttp-missing",
+			"Value of service > pipelines > metrics > exporters on config.yaml does not contain otlphttp")
+	}
+	if slices.Contains(c.Service.Pipelines.Metrics.Receivers, "otlp") {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml contains otlp")
+	} else {
+		reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp")
 	}
 }

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -230,8 +230,7 @@ service:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a temporary config.yaml file
-			configPath := tmpDir + "/"
+			// Write the config to the temp dir and pass its full path.
 			configFile := filepath.Join(tmpDir, "config.yaml")
 			err := os.WriteFile(configFile, []byte(tt.configYAML), 0644)
 			if err != nil {
@@ -242,8 +241,8 @@ service:
 			reporter := utils.Reporter{}
 			componentReporter := reporter.Component("collector")
 
-			// Call the function under test
-			checkCollectorConfig(componentReporter, configPath)
+			// Call the function under test with the full file path.
+			checkCollectorConfig(componentReporter, configFile)
 
 			// Compare the results
 			assert.ElementsMatch(t, tt.expectedErrors, componentReporter.Errors, "errors mismatch")
@@ -288,7 +287,6 @@ service:
       processors: []
       exporters: [otlphttp]
 `
-	configPath := tmpDir + "/"
 	configFile := filepath.Join(tmpDir, "config.yaml")
 	err = os.WriteFile(configFile, []byte(validConfig), 0644)
 	if err != nil {
@@ -299,8 +297,8 @@ service:
 	reporter := utils.Reporter{}
 	componentReporter := reporter.Component("collector")
 
-	// Call the function under test
-	CheckCollectorSetup(componentReporter, "go", configPath)
+	// Call the function under test with the full file path.
+	CheckCollectorSetup(componentReporter, "go", configFile)
 
 	// Expected results
 	expectedChecks := []string{
@@ -329,14 +327,148 @@ func TestMissingConfigFile(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(tmpDir)
 
-	// Create a new reporter for testing
+	// Point the checker at a specific non-existent file inside tmpDir.
+	missing := filepath.Join(tmpDir, "does-not-exist.yaml")
+
+	reporter := utils.Reporter{}
+	componentReporter := reporter.Component("collector")
+	checkCollectorConfig(componentReporter, missing)
+
+	// The tried-paths list is just the explicit file the user asked for.
+	assert.Len(t, componentReporter.Errors, 1, "expected one error")
+	msg := componentReporter.Errors[0]
+	assert.Contains(t, msg, "Could not find a Collector config file", "error should say no config was found")
+	assert.Contains(t, msg, missing, "error should list the path the user provided")
+}
+
+func TestMissingConfigFileFallback(t *testing.T) {
+	// With no path passed, the checker falls back to config.yaml then
+	// config.yml in the current working directory. Chdir to an empty tmp
+	// dir so neither exists.
+	tmpDir, err := os.MkdirTemp("", "collector-fallback-missing-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func(path string) {
+		_ = os.RemoveAll(path)
+	}(tmpDir)
+	origWD, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	reporter := utils.Reporter{}
+	componentReporter := reporter.Component("collector")
+	checkCollectorConfig(componentReporter, "")
+
+	assert.Len(t, componentReporter.Errors, 1, "expected one error")
+	msg := componentReporter.Errors[0]
+	assert.Contains(t, msg, "Could not find a Collector config file")
+	assert.Contains(t, msg, "config.yaml", "fallback list should include config.yaml")
+	assert.Contains(t, msg, "config.yml", "fallback list should include config.yml")
+}
+
+func TestCheckCollectorConfigYmlExtension(t *testing.T) {
+	// Exercise the empty-flag fallback: config.yml (short extension) in the
+	// current working directory must be picked up when the user doesn't pass
+	// --collector-config-path.
+	tmpDir, err := os.MkdirTemp("", "collector-yml-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func(path string) {
+		_ = os.RemoveAll(path)
+	}(tmpDir)
+
+	config := `
+receivers:
+  otlp:
+    protocols:
+      grpc: ""
+      http: ""
+exporters:
+  otlphttp:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yml"), []byte(config), 0644); err != nil {
+		t.Fatalf("Failed to write config.yml: %v", err)
+	}
+
+	origWD, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
 	reporter := utils.Reporter{}
 	componentReporter := reporter.Component("collector")
 
-	// Call the function under test with a path that doesn't have a config.yaml
-	checkCollectorConfig(componentReporter, tmpDir+"/")
+	checkCollectorConfig(componentReporter, "")
 
-	// Expect an error about not being able to find the config file
-	assert.Len(t, componentReporter.Errors, 1, "expected one error")
-	assert.Contains(t, componentReporter.Errors[0], "Could not check file", "error should mention the missing file")
+	assert.Empty(t, componentReporter.Errors, "no errors expected for a valid config.yml")
+	assert.NotEmpty(t, componentReporter.Checks, "expected successful checks against config.yml")
+}
+
+func TestCheckCollectorConfigCustomFilename(t *testing.T) {
+	// The Collector accepts any filename via --config; the checker should too
+	// when the user passes a full path to --collector-config-path.
+	tmpDir, err := os.MkdirTemp("", "collector-custom-name-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func(path string) {
+		_ = os.RemoveAll(path)
+	}(tmpDir)
+
+	config := `
+receivers:
+  otlp:
+    protocols:
+      grpc: ""
+      http: ""
+exporters:
+  otlphttp:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+    logs:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlphttp]
+`
+	customPath := filepath.Join(tmpDir, "my-collector.yaml")
+	if err := os.WriteFile(customPath, []byte(config), 0644); err != nil {
+		t.Fatalf("Failed to write %s: %v", customPath, err)
+	}
+
+	reporter := utils.Reporter{}
+	componentReporter := reporter.Component("collector")
+
+	checkCollectorConfig(componentReporter, customPath)
+
+	assert.Empty(t, componentReporter.Errors, "no errors expected when a valid config with a non-standard filename is passed")
+	assert.NotEmpty(t, componentReporter.Checks, "expected successful checks")
 }

--- a/checks/explain/docs/collector.config.unreadable.md
+++ b/checks/explain/docs/collector.config.unreadable.md
@@ -6,20 +6,21 @@ severity: error
 
 ## Why this matters
 
-`otel-checker check collector` looks for `config.yaml` inside the directory
-passed via `--collector-config-path` (or the current directory when the
-flag is omitted). Every downstream collector check — endpoint format,
-receiver protocols, per-pipeline exporter presence — reads from that
-file. If it can't be opened, the checker has nothing to inspect and skips
-the whole collector-side analysis.
+`otel-checker check collector` reads the Collector's config file from the
+full path passed via `--collector-config-path`. When the flag is omitted,
+it falls back to `config.yaml` (then `config.yml`) in the current working
+directory. Every downstream collector check — endpoint format, receiver
+protocols, per-pipeline exporter presence — reads from that file. If it
+can't be opened, the checker has nothing to inspect and skips the whole
+collector-side analysis.
 
 Common causes:
 
-- Running the checker from a directory that doesn't contain the
-  Collector's config.
-- Passing `--collector-config-path` to a folder that doesn't hold a file
-  literally named `config.yaml` (a different filename, or a symlink to
-  a file the current user can't read).
+- Running the checker from a directory that doesn't contain a
+  `config.yaml` / `config.yml` and not passing `--collector-config-path`.
+- Passing `--collector-config-path` with a wrong path (typo, relative
+  path resolved from a different directory, or pointing at a directory
+  instead of the file itself).
 - Permissions: the config lives on disk but the invoking user doesn't
   have read access.
 
@@ -28,24 +29,22 @@ Common causes:
 1. Confirm the file exists at the expected path:
 
    ```bash
-   ls -l ./config.yaml
+   ls -l ./otel/my-collector.yaml
    ```
 
-2. If your config lives elsewhere, point the checker at its directory:
+2. If your config lives elsewhere or uses a non-standard filename, pass
+   the full file path via `--collector-config-path` (the flag accepts
+   any filename):
 
    ```bash
-   otel-checker check collector --collector-config-path=./otel/
+   otel-checker check collector --collector-config-path=./otel/my-collector.yaml
    ```
-
-   The flag takes a directory; the file inside must be named
-   `config.yaml`. Rename or symlink if your setup uses a different
-   filename.
 
 3. If the file exists but the read failed with `permission denied`, fix
    the permission bits so the checker's user can read it:
 
    ```bash
-   chmod +r ./config.yaml
+   chmod +r ./otel/my-collector.yaml
    ```
 
 ## Example
@@ -62,7 +61,7 @@ my-service/
 Invocation from `my-service/`:
 
 ```bash
-otel-checker check collector --collector-config-path=./otel/
+otel-checker check collector --collector-config-path=./otel/config.yaml
 ```
 
 ## Related

--- a/checks/explain/docs/grafana-cloud.endpoint.localhost.md
+++ b/checks/explain/docs/grafana-cloud.endpoint.localhost.md
@@ -28,7 +28,7 @@ Two options depending on which topology you want to validate:
    instead:
 
    ```bash
-   otel-checker check collector --collector-config-path=./otel/
+   otel-checker check collector --collector-config-path=./otel/config.yaml
    ```
 
    That inspects the Collector's `config.yaml` for the Grafana Cloud

--- a/checks/explain/docs/php.runtime.not-found.md
+++ b/checks/explain/docs/php.runtime.not-found.md
@@ -60,4 +60,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 - `php.runtime.too-old` — related failure when PHP is found but its
   version is below the minimum.
 - `php.composer.not-found` — related failure for the companion tool.
-- [PHP downloads](https://www.php.net/downloads.php)
+- [PHP downloads](https://www.php.net/downloads)

--- a/checks/explain/docs/ruby.cruby.too-old.md
+++ b/checks/explain/docs/ruby.cruby.too-old.md
@@ -60,7 +60,7 @@ ruby -v
 
 ## Related
 
-- [Ruby release schedule](https://www.ruby-lang.org/en/downloads/branches/)
+- [Ruby downloads and maintenance branches](https://www.ruby-lang.org/en/downloads/)
 - [endoflife.date/ruby](https://endoflife.date/ruby) — current status of
   every Ruby major.
 - `ruby.jruby.too-old` — related check for JRuby.

--- a/cmd/otel-checker/check.go
+++ b/cmd/otel-checker/check.go
@@ -51,7 +51,7 @@ func newCheckCmd() *cobra.Command {
 	f.StringVar(&c.PackageJsonPath, "package-json-path", "",
 		"Path to the directory containing package.json (JS only)")
 	f.StringVar(&c.CollectorConfigPath, "collector-config-path", "",
-		"Path to the directory containing the collector's config.yaml")
+		"Full path to the Collector config file. If unset, looks for config.yaml then config.yml in the current directory.")
 
 	_ = cmd.RegisterFlagCompletionFunc("language", staticCompletion(utils.SupportedLanguages))
 

--- a/cmd/otel-checker/check_collector.go
+++ b/cmd/otel-checker/check_collector.go
@@ -18,6 +18,6 @@ func newCheckCollectorCmd(c *utils.Commands) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&c.CollectorConfigPath, "collector-config-path", "",
-		"Path to the directory containing the collector's config.yaml")
+		"Full path to the Collector config file. If unset, looks for config.yaml then config.yml in the current directory.")
 	return cmd
 }

--- a/cmd/otel-checker/run.go
+++ b/cmd/otel-checker/run.go
@@ -23,9 +23,6 @@ func runChecks(ctx context.Context, c utils.Commands) error {
 	if c.PackageJsonPath != "" && !strings.HasSuffix(c.PackageJsonPath, "/") {
 		c.PackageJsonPath += "/"
 	}
-	if c.CollectorConfigPath != "" && !strings.HasSuffix(c.CollectorConfigPath, "/") {
-		c.CollectorConfigPath += "/"
-	}
 	reporter := checks.Run(ctx, c)
 	if err := output.Render(os.Stdout, reporter, c.Format); err != nil {
 		return err


### PR DESCRIPTION
Previously, it was assuming the file name for the collector config was always `config.yaml`, and a different path could be passed, but still using the same name.
The file name can be different, so this updates to accept the entire path including the file name and use both `config.yaml` and `config.yml` on root folder as backups.