### PR TITLE
update check for receiver

### DIFF
--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -101,7 +101,8 @@ func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) 
 	if containsOTLPReceiver(c.Service.Pipelines.Traces.Receivers) {
 		reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml contains otlp")
 	} else {
-		reporter.AddSuccessfulCheck("Value of service > pipelines > traces > receivers on config.yaml does not contain otlp")
+		reporter.AddWarningWithExplain("collector.pipelines.traces-otlp-missing",
+			"Value of service > pipelines > traces > receivers on config.yaml does not contain otlp")
 	}
 
 	// Logs
@@ -114,7 +115,8 @@ func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) 
 	if containsOTLPReceiver(c.Service.Pipelines.Logs.Receivers) {
 		reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml contains otlp")
 	} else {
-		reporter.AddSuccessfulCheck("Value of service > pipelines > logs > receivers on config.yaml does not contain otlp")
+		reporter.AddWarningWithExplain("collector.pipelines.logs-otlp-missing",
+			"Value of service > pipelines > logs > receivers on config.yaml does not contain otlp")
 	}
 
 	// Metrics
@@ -127,7 +129,8 @@ func checkCollectorConfig(reporter *utils.ComponentReporter, configPath string) 
 	if containsOTLPReceiver(c.Service.Pipelines.Metrics.Receivers) {
 		reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml contains otlp")
 	} else {
-		reporter.AddSuccessfulCheck("Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp")
+		reporter.AddWarningWithExplain("collector.pipelines.metrics-otlp-missing",
+			"Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp")
 	}
 }
 

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -346,7 +346,7 @@ service:
 		},
 		{
 			// Every pipeline uses a non-OTLP receiver — this should now warn
-			// per pipeline rather than silently "succeed" as before.
+			// per pipeline.
 			name: "Pipelines fed only by non-OTLP receivers",
 			configYAML: `
 receivers:

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -344,6 +344,53 @@ service:
 				"Value of service > pipelines > metrics > receivers on config.yaml contains otlp",
 			},
 		},
+		{
+			// Every pipeline uses a non-OTLP receiver — this should now warn
+			// per pipeline rather than silently "succeed" as before.
+			name: "Pipelines fed only by non-OTLP receivers",
+			configYAML: `
+receivers:
+  otlp:
+    protocols:
+      grpc: ""
+      http: ""
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'app'
+  filelog:
+    include: [/var/log/app/*.log]
+exporters:
+  otlphttp:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+service:
+  pipelines:
+    traces:
+      receivers: [zipkin]
+      processors: []
+      exporters: [otlphttp]
+    logs:
+      receivers: [filelog]
+      processors: []
+      exporters: [otlphttp]
+    metrics:
+      receivers: [prometheus]
+      processors: []
+      exporters: [otlphttp]
+`,
+			expectedErrors: []string{},
+			expectedWarnings: []string{
+				"Value of service > pipelines > traces > receivers on config.yaml does not contain otlp",
+				"Value of service > pipelines > logs > receivers on config.yaml does not contain otlp",
+				"Value of service > pipelines > metrics > receivers on config.yaml does not contain otlp",
+			},
+			expectedChecks: []string{
+				"Value of exporter > otlphttp > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/checks/explain/docs/collector.pipelines.logs-otlp-missing.md
+++ b/checks/explain/docs/collector.pipelines.logs-otlp-missing.md
@@ -1,0 +1,52 @@
+---
+id: collector.pipelines.logs-otlp-missing
+title: 'Logs pipeline does not accept OTLP input'
+severity: warning
+---
+
+## Why this matters
+
+A Collector `service.pipelines.logs` block wires receivers → processors
+→ exporters for log records. The receivers list is the definitive answer
+to "where do my logs come from?" — if no OTLP receiver (`otlp` or
+`otlp/<name>`) is in that list, this pipeline won't accept log records
+emitted via OTLP by any OpenTelemetry SDK.
+
+That's not always a bug — pipelines fed exclusively by non-OTLP
+receivers are legitimate for services that log to stdout / files rather
+than via the OTel SDK. The warning is a heads-up so you can confirm the
+log source is what you intended.
+
+## How to fix
+
+If your services emit OTLP logs, add `otlp` (or a named `otlp/<name>`
+id) to `service.pipelines.logs.receivers`:
+
+```yaml
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+Multiple receivers are supported — you can fan logs in from OTLP and a
+file source simultaneously:
+
+```yaml
+receivers: [otlp, filelog]
+```
+
+Then confirm the receiver itself is defined in the top-level `receivers`
+block (see `collector.receivers.http-protocol-missing`).
+
+## Related
+
+- `collector.pipelines.traces-otlp-missing` — companion check for the
+  traces pipeline.
+- `collector.pipelines.metrics-otlp-missing` — companion check for the
+  metrics pipeline.
+- `collector.receivers.http-protocol-missing` — related check on the
+  OTLP receiver's `http` protocol.
+- [OpenTelemetry Collector pipelines](https://opentelemetry.io/docs/collector/configuration/#pipelines)

--- a/checks/explain/docs/collector.pipelines.metrics-otlp-missing.md
+++ b/checks/explain/docs/collector.pipelines.metrics-otlp-missing.md
@@ -1,0 +1,53 @@
+---
+id: collector.pipelines.metrics-otlp-missing
+title: 'Metrics pipeline does not accept OTLP input'
+severity: warning
+---
+
+## Why this matters
+
+A Collector `service.pipelines.metrics` block wires receivers →
+processors → exporters for metrics. The receivers list is the
+definitive answer to "where do my metrics come from?" — if no OTLP
+receiver (`otlp` or `otlp/<name>`) is in that list, this pipeline won't
+accept metrics emitted via OTLP by any OpenTelemetry SDK.
+
+That's not always a bug — pipelines fed exclusively by non-OTLP
+receivers (`prometheus` scraping, `hostmetrics`) are legitimate
+for infrastructure-metrics setups where nothing is pushing OTLP.
+The warning is a heads-up so you can confirm the metric source is
+what you intended.
+
+## How to fix
+
+If your services emit OTLP metrics, add `otlp` (or a named `otlp/<name>`
+id) to `service.pipelines.metrics.receivers`:
+
+```yaml
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+Multiple receivers are supported — you can fan metrics in from OTLP and
+a Prometheus scrape simultaneously:
+
+```yaml
+receivers: [otlp, prometheus]
+```
+
+Then confirm the receiver itself is defined in the top-level `receivers`
+block (see `collector.receivers.http-protocol-missing`).
+
+## Related
+
+- `collector.pipelines.traces-otlp-missing` — companion check for the
+  traces pipeline.
+- `collector.pipelines.logs-otlp-missing` — companion check for the
+  logs pipeline.
+- `collector.receivers.http-protocol-missing` — related check on the
+  OTLP receiver's `http` protocol.
+- [OpenTelemetry Collector pipelines](https://opentelemetry.io/docs/collector/configuration/#pipelines)

--- a/checks/explain/docs/collector.pipelines.traces-otlp-missing.md
+++ b/checks/explain/docs/collector.pipelines.traces-otlp-missing.md
@@ -1,0 +1,51 @@
+---
+id: collector.pipelines.traces-otlp-missing
+title: 'Traces pipeline does not accept OTLP input'
+severity: warning
+---
+
+## Why this matters
+
+A Collector `service.pipelines.traces` block wires receivers → processors
+→ exporters for traces. The receivers list is the definitive answer to
+"where do my traces come from?" — if no OTLP receiver (`otlp` or
+`otlp/<name>`) is in that list, this pipeline won't accept traces emitted
+via OTLP by any OpenTelemetry SDK.
+
+That's not always a bug — pipelines fed exclusively by non-OTLP
+receivers are legitimate. The warning is a heads-up so you can confirm
+the trace source is what you intended.
+
+## How to fix
+
+If your services emit OTLP, add `otlp` (or a named `otlp/<name>` id) to
+`service.pipelines.traces.receivers`:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+Multiple receivers are supported — you can fan spans in from OTLP and
+another source simultaneously:
+
+```yaml
+receivers: [otlp, zipkin]
+```
+
+Then confirm the receiver itself is defined in the top-level `receivers`
+block (see `collector.receivers.http-protocol-missing`).
+
+## Related
+
+- `collector.pipelines.logs-otlp-missing` — companion check for the
+  logs pipeline.
+- `collector.pipelines.metrics-otlp-missing` — companion check for the
+  metrics pipeline.
+- `collector.receivers.http-protocol-missing` — related check on the
+  OTLP receiver's `http` protocol.
+- [OpenTelemetry Collector pipelines](https://opentelemetry.io/docs/collector/configuration/#pipelines)


### PR DESCRIPTION
Previously, the collector check was returning success for having or not having otlp. This PR updates to provide a warnings when not available.
Using warning because is not required, and people might be using other names, but is a common usage/recommended.