### PR TITLE
check each exporter

### DIFF
--- a/checks/collector/collectorChecker.go
+++ b/checks/collector/collectorChecker.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -142,25 +143,45 @@ func checkOTLPReceiverHTTPProtocol(reporter *utils.ComponentReporter, receivers 
 		"The value of receivers > otlp > protocols > http is nil. Make sure the key exists on your config.yaml")
 }
 
+// checkOTLPHTTPExporterEndpoint evaluates each otlphttp / otlp_http exporter
+// independently, so a config with a mix of Grafana Cloud and other
+// backends produces one result per exporter:
+//   - Grafana Cloud URL → success
+//   - localhost URL → warning (probably a leftover local-Collector target)
+//   - other well-formed URL → warning (data won't reach Grafana Cloud from
+//     this exporter)
+//   - anything else → error (unparsable, missing scheme/host, or empty)
 func checkOTLPHTTPExporterEndpoint(reporter *utils.ComponentReporter, exporters map[string]exporterConfig) {
-	ids := otlpHTTPExporterIDs(exporters)
-	for _, id := range ids {
-		if otlpHTTPGrafanaEndpointPattern.MatchString(exporters[id].Endpoint) {
+	for _, id := range otlpHTTPExporterIDs(exporters) {
+		endpoint := exporters[id].Endpoint
+		switch {
+		case otlpHTTPGrafanaEndpointPattern.MatchString(endpoint):
 			reporter.AddSuccessfulCheck(fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp", id))
-			return
-		}
-	}
-
-	for _, id := range ids {
-		if strings.Contains(exporters[id].Endpoint, "localhost") {
+		case strings.Contains(endpoint, "localhost"):
 			reporter.AddWarningWithExplain("collector.endpoint.localhost",
 				fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance", id))
-			return
+		case isValidURL(endpoint):
+			reporter.AddWarningWithExplain("collector.endpoint.not-grafana",
+				fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud", id))
+		default:
+			reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
+				fmt.Sprintf("Value of exporter > %s > endpoint on config.yaml is not a valid URL", id))
 		}
 	}
+}
 
-	reporter.AddErrorWithExplain("collector.endpoint.invalid-format",
-		"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp")
+// isValidURL is true when s parses as a URL with both a scheme and a host —
+// that rejects bare strings like "invalid_endpoint" while accepting anything
+// dial-able like "http://prometheus:9090/api/v1/otlp".
+func isValidURL(s string) bool {
+	if s == "" {
+		return false
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return u.Scheme != "" && u.Host != ""
 }
 
 func otlpHTTPExporterIDs(exporters map[string]exporterConfig) []string {

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -415,7 +415,7 @@ service:
 receivers:
   otlp:
     protocols:
-		      grpc: ""
+		  grpc: ""
       http: ""
   prometheus:
     config:

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -100,8 +100,10 @@ service:
       processors: []
       exporters: [otlphttp/grafana_cloud]
 `,
-			expectedErrors:   []string{},
-			expectedWarnings: []string{},
+			expectedErrors: []string{},
+			expectedWarnings: []string{
+				"Value of exporter > otlphttp/local > endpoint on config.yaml is set to localhost. Update to a Grafana endpoint similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp to be able to send telemetry to your Grafana Cloud instance",
+			},
 			expectedChecks: []string{
 				"Value of exporter > otlphttp/grafana_cloud > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
 				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
@@ -176,7 +178,7 @@ service:
       exporters: [otlp_http/invalid]
 `,
 			expectedErrors: []string{
-				"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+				"Value of exporter > otlp_http/invalid > endpoint on config.yaml is not a valid URL",
 			},
 			expectedWarnings: []string{},
 			expectedChecks: []string{
@@ -228,7 +230,10 @@ service:
 			},
 		},
 		{
-			name: "Invalid endpoint format",
+			// A well-formed URL that isn't Grafana Cloud is a warning:
+			// the exporter is technically valid but telemetry from it won't
+			// reach Grafana Cloud.
+			name: "Non-Grafana URL is warned about, not accepted silently",
 			configYAML: `
 receivers:
   otlp:
@@ -253,10 +258,10 @@ service:
       processors: []
       exporters: [otlphttp]
 `,
-			expectedErrors: []string{
-				"Value of exporter > otlphttp > endpoint on config.yaml is not set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+			expectedErrors: []string{},
+			expectedWarnings: []string{
+				"Value of exporter > otlphttp > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud",
 			},
-			expectedWarnings: []string{},
 			expectedChecks: []string{
 				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
 				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
@@ -337,6 +342,64 @@ service:
 			},
 			expectedChecks: []string{
 				"Value of exporter > otlphttp > endpoint on config.yaml set in the format similar to https://otlp-gateway-prod-us-east-0.grafana.net/otlp",
+				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > logs > receivers on config.yaml contains otlp",
+				"Value of service > pipelines > metrics > exporters on config.yaml contains otlphttp",
+				"Value of service > pipelines > metrics > receivers on config.yaml contains otlp",
+			},
+		},
+		{
+			name: "Multi-exporter setup with one invalid and one valid endpoint",
+			configYAML: `
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: detailed
+  otlp_http/grafana_cloud:
+    endpoint: invalid_endpoint
+    auth:
+      authenticator: basicauth/grafana_cloud
+  otlp_http/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp
+  otlp_http/loki:
+    endpoint: http://loki:3100/otlp
+  otlp_http/tempo:
+    endpoint: http://tempo:4318
+  otlp_http/pyroscope:
+    endpoint: http://pyroscope:4040
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [resource/home_monitoring, batch]
+      exporters: [otlp_http/grafana_cloud, otlp_http/prometheus]
+    logs:
+      receivers: [otlp, receiver_creator]
+      processors: [resource/home_monitoring, batch]
+      exporters: [otlp_http/loki, otlp_http/grafana_cloud]
+    traces:
+      receivers: [otlp]
+      processors: [resource/home_monitoring, batch]
+      exporters: [otlp_http/grafana_cloud, otlp_http/tempo]
+`,
+			expectedErrors: []string{
+				"Value of exporter > otlp_http/grafana_cloud > endpoint on config.yaml is not a valid URL",
+			},
+			expectedWarnings: []string{
+				"Value of exporter > otlp_http/prometheus > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud",
+				"Value of exporter > otlp_http/loki > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud",
+				"Value of exporter > otlp_http/tempo > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud",
+				"Value of exporter > otlp_http/pyroscope > endpoint on config.yaml is a valid URL but is not a Grafana Cloud endpoint. Data from this exporter will not reach Grafana Cloud",
+			},
+			expectedChecks: []string{
+				"Value of service > pipelines > traces > exporters on config.yaml contains otlphttp",
 				"Value of service > pipelines > traces > receivers on config.yaml contains otlp",
 				"Value of service > pipelines > logs > exporters on config.yaml contains otlphttp",
 				"Value of service > pipelines > logs > receivers on config.yaml contains otlp",

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -415,7 +415,7 @@ service:
 receivers:
   otlp:
     protocols:
-		  grpc: ""
+      grpc: ""
       http: ""
   prometheus:
     config:

--- a/checks/collector/collectorChecker_test.go
+++ b/checks/collector/collectorChecker_test.go
@@ -355,7 +355,7 @@ service:
 receivers:
   otlp:
     protocols:
-		  grpc:
+      grpc:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318

--- a/checks/explain/docs/collector.endpoint.not-grafana.md
+++ b/checks/explain/docs/collector.endpoint.not-grafana.md
@@ -1,0 +1,64 @@
+---
+id: collector.endpoint.not-grafana
+title: 'Collector exporter endpoint is a valid URL but not a Grafana Cloud endpoint'
+severity: warning
+---
+
+## Why this matters
+
+An `otlphttp` / `otlp_http` exporter in your Collector config is
+configured with a well-formed URL that doesn't match the Grafana Cloud
+OTLP gateway pattern (`https://*.grafana.net/otlp`). The Collector will
+happily start with this configuration — the exporter is valid — but any
+telemetry routed through it goes to a different backend, not to
+Grafana Cloud.
+
+This is a common intentional setup: the Collector fans out to multiple
+backends, and only *some* exporters point at Grafana Cloud. The warning
+is a heads-up, not a bug — it lists which exporters are shipping data
+elsewhere so you can confirm each is on purpose.
+
+## How to fix
+
+If the endpoint is intentional (e.g. `otlp_http/prometheus` routing to a
+Prometheus server), no action is required — the warning is informational
+and safe to ignore. Verify by checking which exporter each pipeline uses
+in `service.pipelines.*.exporters`.
+
+If the endpoint was meant to be Grafana Cloud, replace it with your
+stack's OTLP gateway URL (found under **Connections → OpenTelemetry
+(OTLP) → Send data** in the Grafana Cloud UI):
+
+```yaml
+exporters:
+  otlphttp/grafana_cloud:
+    endpoint: https://otlp-gateway-<zone>.grafana.net/otlp
+    auth:
+      authenticator: basicauth/grafana_cloud
+```
+
+Do not include a per-signal suffix (`/v1/traces`, `/v1/metrics`,
+`/v1/logs`). The `otlphttp` exporter appends those itself.
+
+## Example
+
+Common multi-backend fan-out where the warning is expected on the
+non-Grafana exporters:
+
+```yaml
+exporters:
+  otlp_http/grafana_cloud:
+    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp   # → success
+  otlp_http/prometheus:
+    endpoint: http://prometheus:9090/api/v1/otlp                    # → this warning
+  otlp_http/loki:
+    endpoint: http://loki:3100/otlp                                 # → this warning
+```
+
+## Related
+
+- [Grafana Cloud OTLP endpoint reference](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/)
+- `collector.endpoint.localhost` — companion warning when a Collector
+  exporter still points at `localhost`.
+- `collector.endpoint.invalid-format` — companion error when the
+  endpoint isn't a well-formed URL at all.

--- a/checks/explain/docs/php.runtime.not-found.md
+++ b/checks/explain/docs/php.runtime.not-found.md
@@ -60,4 +60,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 - `php.runtime.too-old` — related failure when PHP is found but its
   version is below the minimum.
 - `php.composer.not-found` — related failure for the companion tool.
-- [PHP downloads](https://www.php.net/downloads)
+- [PHP installation manual](https://www.php.net/manual/en/install.php)

--- a/checks/explain/docs/php.runtime.not-found.md
+++ b/checks/explain/docs/php.runtime.not-found.md
@@ -60,4 +60,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 - `php.runtime.too-old` — related failure when PHP is found but its
   version is below the minimum.
 - `php.composer.not-found` — related failure for the companion tool.
-- [PHP installation manual](https://www.php.net/manual/en/install.php)
+- [PHP installation manual](https://www.php.net/manual/install.php)


### PR DESCRIPTION
Previously, it was checking just one exporter, even when there was an array. Now it checks each other and adds the error/warning/success for each one.

- Grafana Cloud URL → success
- localhost URL → warning (probably a leftover local-Collector target)
- other well-formed URL → warning (data won't reach Grafana Cloud from this exporter, but might be a valid case of sending somewhere else)
- anything else → error (unparsable, missing scheme/host, or empty)

Updated existing tests to pass and added a new test that had a valid and invalid endpoint to trigger both cases at the same time