### PR TITLE
ci: limit release jobs to required mise tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
     if: github.event_name == 'push' && needs.release-please.outputs.release_created == 'true'
     needs: release-please
     runs-on: ubuntu-24.04
+    env:
+      MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write
       contents: write
@@ -52,6 +54,7 @@ jobs:
         with:
           version: v2026.7.7
           sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+          cache: false
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,6 +72,8 @@ jobs:
   publish-existing-tag:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
+    env:
+      MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write
       contents: write
@@ -96,6 +101,7 @@ jobs:
         with:
           version: v2026.7.7
           sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+          cache: false
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
     needs: release-please
     runs-on: ubuntu-24.04
     env:
+      # Keep artifact releases isolated from unrelated mise tools and caches.
       MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write
@@ -73,6 +74,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     env:
+      # Keep artifact releases isolated from unrelated mise tools and caches.
       MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     needs: release-please
     runs-on: ubuntu-24.04
     env:
-      # Keep artifact releases isolated from unrelated mise tools and caches.
+      # Artifact releases pair a focused tool allowlist with cache: false.
       MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write
@@ -74,7 +74,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     env:
-      # Keep artifact releases isolated from unrelated mise tools and caches.
+      # Artifact releases pair a focused tool allowlist with cache: false.
       MISE_ENABLE_TOOLS: go,goreleaser
     permissions:
       attestations: write


### PR DESCRIPTION
## What changed

- Restrict the artifact release job to the mise tools it actually requires.
- Keep mise-action caching disabled for release artifacts.

## Why

Focused release jobs should not install every development and linting tool from `mise.toml`. Apart from wasting time, unrelated tool resolution can fail and block an otherwise valid release build.

## Validation

- `mise run lint:fix`
- `git diff --check`
