### PR TITLE
docs: add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,3 +154,4 @@ otel-checker check --language=js --format=json > results.json    # capture for e
   typos, editorconfig-checker, golangci-lint, gofmt, ruff, ruff-format,
   biome, biome-format, lychee, renovate-deps)
 - Python scripts use uv for dependencies
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
