### PR TITLE
chore: enable Flint GitHub Actions tracking

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -3,4 +3,4 @@
 exclude = [".vscode/launch.json", "**/supported-libraries.yaml"]
 
 [checks.renovate-deps]
-exclude_managers = ["github-actions", "github-runners", "gomod"]
+exclude_managers = ["github-runners", "gomod"]

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -7,18 +7,35 @@
       ]
     },
     ".github/workflows/lint.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
+      ]
+    },
+    ".github/workflows/pr-title.yml": {
+      "github-actions": [
+        "grafana/shared-workflows",
+        "ubuntu"
       ]
     },
     ".github/workflows/release.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/attest-build-provenance",
+        "actions/checkout",
+        "googleapis/release-please-action",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
       ]
     },
     ".github/workflows/test.yaml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
       ]
     },
     "mise.toml": {
@@ -43,6 +60,29 @@
         "uv",
         "zizmor"
       ]
+    }
+  },
+  "actionMeta": {
+    "actions/attest-build-provenance": {
+      "packageName": "actions/attest-build-provenance",
+      "refKind": "version-tag"
+    },
+    "actions/checkout": {
+      "packageName": "actions/checkout",
+      "refKind": "version-tag"
+    },
+    "googleapis/release-please-action": {
+      "packageName": "googleapis/release-please-action",
+      "refKind": "version-tag"
+    },
+    "grafana/shared-workflows/actions/lint-pr-title": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "lint-pr-title"
+    },
+    "jdx/mise-action": {
+      "packageName": "jdx/mise-action",
+      "refKind": "version-tag"
     }
   }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   extends: [
     "config:best-practices",
     "helpers:pinGitHubActionDigestsToSemver",
-    "github>grafana/flint#v0.22.10",
+    "github>grafana/flint#v0.22.11",
   ],
   automerge: true,
   labels: ["dependencies"],

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ uv = "0.12.5"
 
 # Linters
 actionlint = "1.7.12"
-"aqua:grafana/flint" = "0.22.10"
+"aqua:grafana/flint" = "0.22.11"
 "aqua:owenlamont/ryl" = "0.21.0"
 biome = "2.5.8"
 editorconfig-checker = "3.11.1"


### PR DESCRIPTION
## What changed

- Update Flint to v0.22.11.
- Enable `github-actions` in the `renovate-deps` linter.
- Regenerate the tracked dependency snapshot with GitHub Action ref metadata.

## Why

Flint v0.22.11 records action ref shapes and rejects deterministic Renovate digest lookup failures, guarding component-prefixed shared-workflow tags and branch-pinned reusable workflows.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `git diff --check`

Related to https://github.com/grafana/shared-workflows/issues/2255